### PR TITLE
Add WhatsApp chat and support center pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,8 @@ import TemplateDetail from "./pages/TemplateDetail";
 import PaymentSuccess from "./pages/PaymentSuccess";
 import PaymentCanceled from "./pages/PaymentCanceled";
 import EmailCorporativo from "./pages/EmailCorporativo";
+import ChatWhatsapp from "./pages/ChatWhatsapp";
+import CentralAtendimento from "./pages/CentralAtendimento";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -33,6 +35,8 @@ const App = () => (
           <Route path="/templates" element={<Templates />} />
           <Route path="/templates/:slug" element={<TemplateDetail />} />
           <Route path="/email-corporativo" element={<EmailCorporativo />} />
+          <Route path="/chat-whatsapp" element={<ChatWhatsapp />} />
+          <Route path="/central-atendimento" element={<CentralAtendimento />} />
           <Route path="/payment-success" element={<PaymentSuccess />} />
           <Route path="/payment-canceled" element={<PaymentCanceled />} />
           <Route path="/admin" element={<Admin />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -14,6 +14,8 @@ export const Header = () => {
     { name: "Portfolio", href: "/#portfolio", type: "anchor" },
     { name: "Templates", href: "/templates", type: "link" },
     { name: "E-mail Corporativo", href: "/email-corporativo", type: "link" },
+    { name: "Chat Whatsapp", href: "/chat-whatsapp", type: "link" },
+    { name: "Central de Atendimento", href: "/central-atendimento", type: "link" },
     { name: "Blog", href: "/blog", type: "link" },
     { name: "Cases", href: "/cases", type: "link" },
     { name: "Contato", href: "/#contact", type: "anchor" },

--- a/frontend/src/pages/CentralAtendimento.tsx
+++ b/frontend/src/pages/CentralAtendimento.tsx
@@ -1,0 +1,135 @@
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CheckCircle, Calendar, PhoneCall, Clock, Plug } from "lucide-react";
+
+const features = [
+  { icon: CheckCircle, text: "Chamados abertos, pendentes, resolvidos e chatbot" },
+  { icon: CheckCircle, text: "Funil de vendas, exportação das conversas em PDF, logs e registros" },
+  { icon: CheckCircle, text: "Sincronização com Typebot, ChatGPT e n8n" },
+  { icon: CheckCircle, text: "Gestão de oportunidades com ações, calendário e visualização kanban" },
+  { icon: CheckCircle, text: "Mensagens rápidas" },
+  { icon: Calendar, text: "Agendamento de mensagens com parâmetros (ex: aniversariantes)" },
+  { icon: PhoneCall, text: "Suporte para chamadas VoIP e logs" },
+  { icon: CheckCircle, text: "Avaliação de atendimento" },
+  { icon: Clock, text: "Horário de atendimento configurável com cadastro de feriados" },
+  { icon: Plug, text: "Integração com API externa" },
+];
+
+const aiIntegrations = [
+  "Typebot", "ChatGPT", "Grok", "Gemini", "Qwen", "Claude", "DeepSeek",
+  "n8n", "Dify", "Ollama", "LM Studio", "Dialogflow"
+];
+
+const otherIntegrations = [
+  "Webhooks", "Meta", "Webchat", "Evolution API", "Wuzapi API",
+  "Hub Notificame", "SMS Vapi", "groqCloud"
+];
+
+const CentralAtendimento = () => {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+
+      {/* Hero */}
+      <section className="pt-24 pb-16 px-4 bg-gradient-to-br from-primary/5 via-background to-primary/5 text-center">
+        <div className="container mx-auto">
+          <Badge className="mb-4 px-4 py-2">Central de Atendimento</Badge>
+          <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
+            Plataforma de Atendimento Completa
+          </h1>
+          <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+            Organize suas conversas, automatize processos e integre seu atendimento com as principais ferramentas do mercado.
+          </p>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="py-16 px-4">
+        <div className="container mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-12">Recursos</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            {features.map((f, idx) => (
+              <Card key={idx} className="hover:shadow-lg transition-shadow">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <f.icon className="w-5 h-5 text-primary" />
+                    {f.text}
+                  </CardTitle>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Integrations */}
+      <section className="py-16 px-4 bg-muted/30">
+        <div className="container mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-6">Integrações</h2>
+          <p className="text-center text-muted-foreground mb-8">Conecte sua central às principais plataformas do mercado.</p>
+          <div className="grid md:grid-cols-2 gap-8">
+            <Card>
+              <CardHeader>
+                <CardTitle>IA e Automação</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {aiIntegrations.map(name => (
+                  <Badge key={name} variant="secondary">{name}</Badge>
+                ))}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Outras Conexões</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {otherIntegrations.map(name => (
+                  <Badge key={name} variant="secondary">{name}</Badge>
+                ))}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* Additional */}
+      <section className="py-16 px-4">
+        <div className="container mx-auto space-y-12 max-w-3xl">
+          <Card>
+            <CardHeader>
+              <CardTitle>Testar BM</CardTitle>
+            </CardHeader>
+            <CardContent className="text-muted-foreground">
+              Verificação para confirmar integração com a Meta. Em caso de erro, o sistema informa imediatamente.
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Templates de Configuração</CardTitle>
+            </CardHeader>
+            <CardContent className="text-muted-foreground">
+              Modelos prontos para agilizar a implementação de fluxos e integrações.
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Valores</CardTitle>
+            </CardHeader>
+            <CardContent className="text-muted-foreground">
+              Planos com o mínimo de 5 usuários a partir de <strong>R$ 50,00 por mês</strong>.
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default CentralAtendimento;
+

--- a/frontend/src/pages/ChatWhatsapp.tsx
+++ b/frontend/src/pages/ChatWhatsapp.tsx
@@ -1,0 +1,81 @@
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Users, QrCode, Plug } from "lucide-react";
+
+const ChatWhatsapp = () => {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+
+      {/* Hero */}
+      <section className="pt-24 pb-16 px-4 bg-gradient-to-br from-primary/5 via-background to-primary/5 text-center">
+        <div className="container mx-auto">
+          <Badge className="mb-4 px-4 py-2">Chat Whatsapp</Badge>
+          <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
+            Atendimento no Whatsapp
+          </h1>
+          <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+            Conecte seu negócio ao Whatsapp e distribua conversas para diversos usuários com um único número.
+          </p>
+        </div>
+      </section>
+
+      {/* Connection Options */}
+      <section className="py-16 px-4">
+        <div className="container mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-12">Formas de Conexão</h2>
+          <div className="grid md:grid-cols-2 gap-6">
+            <Card className="hover:shadow-lg transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Plug className="w-6 h-6 text-primary" />
+                  API Oficial
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-muted-foreground">
+                <p>Integração indicada para operações que exigem estabilidade e alto volume.</p>
+                <ul className="list-disc list-inside text-sm">
+                  <li>Sem limite prático de contas conectadas.</li>
+                  <li>Tempo de resposta otimizado.</li>
+                  <li>Recomendado para empresas em crescimento.</li>
+                </ul>
+              </CardContent>
+            </Card>
+            <Card className="hover:shadow-lg transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <QrCode className="w-6 h-6 text-primary" />
+                  Conexão via QR Code
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-muted-foreground">
+                <p>Opção simples para iniciar rapidamente sem necessidade de homologação.</p>
+                <ul className="list-disc list-inside text-sm">
+                  <li>Suporta no máximo 3 contas.</li>
+                  <li>Tempo de resposta pode variar conforme o dispositivo.</li>
+                  <li>Ideal para testes ou pequenas equipes.</li>
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+          <div className="mt-12 text-center text-muted-foreground max-w-2xl mx-auto">
+            <div className="flex items-center justify-center gap-2 mb-2">
+              <Users className="w-5 h-5 text-primary" />
+              <span className="font-medium text-foreground">Um número geral, vários usuários</span>
+            </div>
+            <p>
+              Independentemente da forma de conexão, todas as mensagens chegam a um número único e podem ser atendidas por diferentes usuários simultaneamente.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default ChatWhatsapp;
+


### PR DESCRIPTION
## Summary
- add Chat Whatsapp page explaining API vs QR code connection
- add Central de Atendimento page with features, integrations and pricing
- register new pages in router and header navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in CaseDetail.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b339458c8330ac4647fec2abdce6