### PR TITLE
Fix case image URLs and standardize case data parsing

### DIFF
--- a/frontend/src/lib/caseUtils.ts
+++ b/frontend/src/lib/caseUtils.ts
@@ -1,0 +1,29 @@
+export type Metric = { label: string; value: string; description?: string } | string;
+
+export interface CaseItem {
+  slug: string;
+  title: string;
+  client: string;
+  date: string;
+  coverImage: string;
+  excerpt: string;
+  challenge: string;
+  solution: string;
+  results: string;
+  gallery: string[];
+  tags: string[];
+  metrics: Metric[];
+}
+
+export const safeArray = <T>(value: T[] | string | null | undefined): T[] => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+};

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -3,37 +3,7 @@ import { ArrowLeft, Calendar, TrendingUp, Target, Lightbulb, Trophy, ArrowRight 
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { useEffect, useState } from "react";
-
-type Metric = { label: string; value: string; description?: string } | string;
-
-interface CaseItem {
-  slug: string;
-  title: string;
-  client: string;
-  date: string;
-  coverImage: string;
-  excerpt: string;
-  challenge: string;
-  solution: string;
-  results: string;
-  gallery: string[] | string | null;
-  tags: string[] | string | null;
-  metrics: Metric[] | string | null;
-}
-
-const safeArray = (v: any): any[] =>
-  Array.isArray(v)
-    ? v
-    : typeof v === "string"
-    ? (() => {
-        try {
-          const j = JSON.parse(v);
-          return Array.isArray(j) ? j : [];
-        } catch {
-          return [];
-        }
-      })()
-    : [];
+import { CaseItem, Metric, safeArray } from "@/lib/caseUtils";
 
 export const CaseDetail = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -49,14 +19,26 @@ export const CaseDetail = () => {
         if (res.ok) {
           const text = await res.text();
           if (!text) throw new Error("Resposta vazia do servidor");
-          const data = JSON.parse(text);
-          setCaseItem(data);
+          const data = JSON.parse(text) as Record<string, unknown>;
+          const parsed: CaseItem = {
+            ...(data as Omit<CaseItem, "tags" | "gallery" | "metrics">),
+            tags: safeArray<string>(data.tags as string[] | string | null | undefined),
+            gallery: safeArray<string>(data.gallery as string[] | string | null | undefined),
+            metrics: safeArray<Metric>(data.metrics as Metric[] | string | null | undefined),
+          };
+          setCaseItem(parsed);
           const relRes = await fetch(`${API}/cases`);
           if (relRes.ok) {
             const relText = await relRes.text();
             if (!relText) throw new Error("Resposta vazia do servidor");
-            const all = JSON.parse(relText);
-            setRelatedCases(all.filter((c: CaseItem) => c.slug !== data.slug).slice(0, 3));
+            const rawCases = JSON.parse(relText) as Array<Record<string, unknown>>;
+            const all: CaseItem[] = rawCases.map((c) => ({
+              ...(c as Omit<CaseItem, "tags" | "gallery" | "metrics">),
+              tags: safeArray<string>(c.tags as string[] | string | null | undefined),
+              gallery: safeArray<string>(c.gallery as string[] | string | null | undefined),
+              metrics: safeArray<Metric>(c.metrics as Metric[] | string | null | undefined),
+            }));
+            setRelatedCases(all.filter((c) => c.slug !== parsed.slug).slice(0, 3));
           }
         }
       } catch (err) {
@@ -86,10 +68,6 @@ export const CaseDetail = () => {
       </div>
     );
   }
-  const tags = safeArray(caseItem.tags);
-  const metrics = safeArray(caseItem.metrics);
-  const gallery = safeArray(caseItem.gallery);
-
   return (
     <div className="min-h-screen bg-background">
       <Header />
@@ -135,9 +113,9 @@ export const CaseDetail = () => {
                 </div>
 
                 {/* Tags */}
-                {tags.length > 0 && (
+                {caseItem.tags.length > 0 && (
                   <div className="flex flex-wrap gap-2">
-                    {tags.map((tag) => (
+                    {caseItem.tags.map((tag) => (
                       <span
                         key={tag}
                         className="px-3 py-1 text-xs rounded-full bg-secondary text-secondary-foreground"
@@ -152,7 +130,7 @@ export const CaseDetail = () => {
               {/* Featured Image */}
               <div className="relative h-64 md:h-96 overflow-hidden rounded-2xl">
                 <img
-                  src={`https://images.unsplash.com/${caseItem.coverImage}?w=800&h=600&fit=crop`}
+                  src={caseItem.coverImage}
                   alt={caseItem.title}
                   className="w-full h-full object-cover"
                 />
@@ -164,12 +142,12 @@ export const CaseDetail = () => {
       </section>
 
       {/* Metrics Section */}
-      {metrics.length > 0 && (
+      {caseItem.metrics.length > 0 && (
         <section className="py-16 bg-gradient-navy">
           <div className="container mx-auto px-4">
             <div className="max-w-6xl mx-auto">
               <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-                {metrics.map((metric, index) => (
+                {caseItem.metrics.map((metric, index) => (
                   <div
                     key={index}
                     className="glass rounded-2xl p-6 text-center hover-lift animate-fade-in-up"
@@ -249,7 +227,7 @@ export const CaseDetail = () => {
       </section>
 
       {/* Gallery */}
-      {gallery.length > 0 && (
+      {caseItem.gallery.length > 0 && (
         <section className="py-16 bg-gradient-navy">
           <div className="container mx-auto px-4">
             <div className="max-w-6xl mx-auto">
@@ -258,16 +236,16 @@ export const CaseDetail = () => {
                   Galeria do Projeto
                 </span>
               </h2>
-              
+
               <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {gallery.map((image, index) => (
-                  <div 
+                {caseItem.gallery.map((image, index) => (
+                  <div
                     key={index}
                     className="relative h-64 overflow-hidden rounded-2xl hover-lift animate-fade-in-up"
                     style={{ animationDelay: `${index * 0.1}s` }}
                   >
                     <img
-                      src={`https://images.unsplash.com/${image}?w=600&h=400&fit=crop`}
+                      src={image}
                       alt={`${caseItem.title} - Imagem ${index + 1}`}
                       className="w-full h-full object-cover transition-transform duration-500 hover:scale-110"
                     />
@@ -296,7 +274,7 @@ export const CaseDetail = () => {
                   <article key={relatedCase.slug} className="glass rounded-2xl overflow-hidden hover-lift group">
                     <div className="relative h-48 overflow-hidden">
                       <img
-                        src={`https://images.unsplash.com/${relatedCase.coverImage}?w=400&h=300&fit=crop`}
+                        src={relatedCase.coverImage}
                         alt={relatedCase.title}
                         className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                       />

--- a/frontend/src/pages/CasesList.tsx
+++ b/frontend/src/pages/CasesList.tsx
@@ -3,21 +3,7 @@ import { ArrowRight, ExternalLink, TrendingUp } from "lucide-react";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { useEffect, useState } from "react";
-
-interface CaseItem {
-  slug: string;
-  title: string;
-  client: string;
-  date: string;
-  coverImage: string;
-  excerpt: string;
-  challenge: string;
-  solution: string;
-  results: string;
-  gallery: string[];
-  tags: string[];
-  metrics: { label: string; value: string; description: string }[];
-}
+import { CaseItem, Metric, safeArray } from "@/lib/caseUtils";
 
 export const CasesList = () => {
   const [items, setItems] = useState<CaseItem[]>([]);
@@ -30,8 +16,14 @@ export const CasesList = () => {
         if (res.ok) {
           const text = await res.text();
           if (!text) throw new Error("Resposta vazia do servidor");
-          const data = JSON.parse(text);
-          setItems(data);
+          const data = JSON.parse(text) as Array<Record<string, unknown>>;
+          const parsed: CaseItem[] = data.map((item) => ({
+            ...(item as Omit<CaseItem, "tags" | "gallery" | "metrics">),
+            tags: safeArray<string>(item.tags as string[] | string | null | undefined),
+            gallery: safeArray<string>(item.gallery as string[] | string | null | undefined),
+            metrics: safeArray<Metric>(item.metrics as Metric[] | string | null | undefined),
+          }));
+          setItems(parsed);
         }
       } catch (err) {
         console.error('fetch cases', err);
@@ -108,7 +100,7 @@ export const CasesList = () => {
                   {/* Case Image */}
                   <div className="relative h-64 overflow-hidden">
                     <img
-                      src={`https://images.unsplash.com/${caseItem.coverImage}?w=800&h=400&fit=crop`}
+                      src={caseItem.coverImage}
                       alt={caseItem.title}
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />


### PR DESCRIPTION
## Summary
- add shared case utilities for typing and safe array parsing
- use backend-provided image URLs in cases list and detail pages
- parse case data consistently in list and detail views

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba7938048330b5a44d40453c240e