### PR TITLE
chore: normalize portfolio images

### DIFF
--- a/frontend/src/components/Portfolio.tsx
+++ b/frontend/src/components/Portfolio.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { ExternalLink, Filter } from "lucide-react";
 import { Link } from "react-router-dom";
+import { normalizeImageUrl } from "@/lib/utils";
 
 interface Case {
   id: number;
@@ -44,7 +45,7 @@ export const Portfolio = () => {
     slug: caseItem.slug,
     title: caseItem.title,
     description: caseItem.excerpt,
-    image: caseItem.coverImage,
+    image: normalizeImageUrl(caseItem.coverImage),
     tags: caseItem.tags,
     results: caseItem.metrics[0]?.value || "Ver resultados"
   }));
@@ -107,7 +108,7 @@ export const Portfolio = () => {
                   {/* Project Image */}
                   <div className="relative h-48 overflow-hidden">
                     <img
-                      src={`https://images.unsplash.com/${project.image}?w=600&h=400&fit=crop`}
+                      src={project.image}
                       alt={project.title}
                       className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
                     />

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function normalizeImageUrl(image: string, width = 600, height = 400) {
+  if (!image) return ""
+  if (image.startsWith("http")) return image
+  return `https://images.unsplash.com/${image}?w=${width}&h=${height}&fit=crop`
+}


### PR DESCRIPTION
## Summary
- normalize case cover images using `normalizeImageUrl`
- simplify portfolio image rendering to use normalized URLs

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8c2a31e808330a68ee63e7c95aabc