### PR TITLE
Update pricing and hero spacing

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import heroBackground from "@/assets/hero-background.jpg";
 
 export const Hero = () => {
   return (
-    <section id="hero" className="min-h-screen pt-24 flex items-center justify-center relative overflow-hidden">
+    <section id="hero" className="min-h-screen pt-32 md:pt-36 pb-16 flex items-center justify-center relative overflow-hidden">
       {/* Background Image */}
       <div 
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"

--- a/frontend/src/pages/CentralAtendimento.tsx
+++ b/frontend/src/pages/CentralAtendimento.tsx
@@ -7,7 +7,7 @@ import { KanbanSquare, Star, Zap } from "lucide-react";
 export function CentralAtendimento() {
   return (
     <main className="min-h-screen">
-      <section className="container mx-auto px-4 py-16 md:py-24" aria-labelledby="central-hero">
+      <section className="container mx-auto px-4 pt-32 md:pt-36 pb-16" aria-labelledby="central-hero">
         <Badge variant="secondary" className="mb-3">Central de Atendimento</Badge>
         <h1 id="central-hero" className="text-3xl md:text-5xl font-bold tracking-tight">Central de Conversas com funil</h1>
         <p className="mt-4 text-muted-foreground text-lg">
@@ -61,7 +61,7 @@ export function CentralAtendimento() {
             <CardDescription>Mínimo de 5 usuários por conta</CardDescription>
           </CardHeader>
           <CardContent className="text-sm md:text-base text-muted-foreground">
-            <p><b>Base:</b> R$ 750/mês (mínimo de 5 usuários).</p>
+            <p><b>Base:</b> R$ 1.533/ano (plano anual para até 5 usuários).</p>
             <div className="mt-4 flex gap-3">
               <a
                 href="https://api.whatsapp.com/send?phone=5519982403845"

--- a/frontend/src/pages/ChatWhatsapp.tsx
+++ b/frontend/src/pages/ChatWhatsapp.tsx
@@ -7,7 +7,7 @@ export default function ChatWhatsapp() {
   return (
     <main className="min-h-screen">
       {/* Hero */}
-      <section className="container mx-auto px-4 py-16 md:py-24" aria-labelledby="chatwhats-hero">
+      <section className="container mx-auto px-4 pt-32 md:pt-36 pb-16" aria-labelledby="chatwhats-hero">
         <div className="grid md:grid-cols-2 gap-10 items-center">
           <div>
             <Badge variant="secondary" className="mb-3">WhatsApp Omnichannel</Badge>
@@ -154,7 +154,7 @@ export default function ChatWhatsapp() {
             <CardDescription>Mínimo de 5 usuários por conta</CardDescription>
           </CardHeader>
           <CardContent className="text-sm md:text-base text-muted-foreground">
-            <p><b>Base:</b> R$ 750/mês (mínimo de 5 usuários).</p>
+            <p><b>Base:</b> R$ 1.533/ano (plano anual para até 5 usuários).</p>
             <div className="mt-4 flex gap-3">
               <a
                 href="https://api.whatsapp.com/send?phone=5519982403845"


### PR DESCRIPTION
## Summary
- update pricing copy for Chat WhatsApp and Central de Atendimento pages
- add extra top padding to hero sections to avoid overlap with sticky header
- adjust home hero component spacing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9053bee1c8330b65f819f7434806c