### PR TITLE
chore: ignore node_modules directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ backend/coverage/
 .vscode/
 .idea/
 *.iml
+
+# Stripe system
+winove-stripe-system/node_modules/


### PR DESCRIPTION
## Summary
- ensure node_modules directories are ignored, including stripe system

## Testing
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (winove-stripe-system) *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68aa87960cb08330a3bd8ba604592b21