### PR TITLE
feat: add promotions page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import PaymentCanceled from "./pages/PaymentCanceled";
 import EmailCorporativo from "./pages/EmailCorporativo";
 import ChatWhatsapp from "@/pages/ChatWhatsapp";
 import { CentralAtendimento } from "@/pages/CentralAtendimento";
+import Promocoes from "./pages/Promocoes";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -40,6 +41,7 @@ const App = () => (
           <Route path="/chat-whatsapp" element={<ChatWhatsapp />} />
           <Route path="/chatwhatsapp" element={<ChatWhatsapp />} />
           <Route path="/central-atendimento" element={<CentralAtendimento />} />
+          <Route path="/promocoes" element={<Promocoes />} />
           <Route path="/payment-success" element={<PaymentSuccess />} />
           <Route path="/payment-canceled" element={<PaymentCanceled />} />
           <Route path="/admin" element={<Admin />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -48,7 +48,9 @@ export const Header = () => {
       {/* Faixa superior */}
       <div className="bg-primary text-primary-foreground text-sm flex items-center justify-center py-1">
         <span>Veja as promoções atuais</span>
-        <Button className="btn-secondary ml-4 px-3 py-1 text-xs">Ver mais</Button>
+        <Link to="/promocoes">
+          <Button className="btn-secondary ml-4 px-3 py-1 text-xs">Ver mais</Button>
+        </Link>
       </div>
 
       <div className="container mx-auto px-4 py-4">

--- a/frontend/src/pages/Promocoes.tsx
+++ b/frontend/src/pages/Promocoes.tsx
@@ -1,0 +1,61 @@
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+
+const Promocoes = () => {
+  const promotions = [
+    {
+      title: "Templates com 20% de desconto",
+      description: "Aproveite nossos templates profissionais com um desconto especial neste mês.",
+      link: "/templates",
+    },
+    {
+      title: "E-mail Corporativo 10% off",
+      description: "Tenha um e-mail profissional com preço reduzido durante o período promocional.",
+      link: "/email-corporativo",
+    },
+    {
+      title: "Chat WhatsApp gratuito na contratação de sites",
+      description: "Contrate um site e ganhe nosso sistema de chat WhatsApp por tempo limitado.",
+      link: "/chat-whatsapp",
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+      <section className="pt-24 pb-16 px-4">
+        <div className="container mx-auto text-center">
+          <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
+            Promoções do Mês
+          </h1>
+          <p className="text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+            Confira as ofertas especiais que preparamos para você.
+          </p>
+        </div>
+        <div className="container mx-auto grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          {promotions.map((promo) => (
+            <Card key={promo.title} className="hover:shadow-lg transition-shadow duration-300">
+              <CardHeader>
+                <CardTitle>{promo.title}</CardTitle>
+              </CardHeader>
+              <CardContent className="text-muted-foreground">
+                <p>{promo.description}</p>
+              </CardContent>
+              <CardFooter>
+                <Link to={promo.link}>
+                  <Button className="btn-primary">Saiba mais</Button>
+                </Link>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+};
+
+export default Promocoes;


### PR DESCRIPTION
## Summary
- add promotions page with sample offers
- route to new promotions page
- link header banner to promotions page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any in src/lib/api.ts and src/pages/Templates.tsx)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b4a12457748330bb45ce49b6383558