### PR TITLE
feat: generate and publish sitemaps during deploy

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "prestart": "node scripts/build-and-sync.mjs",
+    "sitemap": "node scripts/generate-sitemap.mjs",
     "migrate": "node scripts/migrate.mjs",
     "start": "node index.js",
     "deploy": "bash ../deploy/deploy.sh"

--- a/backend/scripts/generate-sitemap.mjs
+++ b/backend/scripts/generate-sitemap.mjs
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pool } from '../db.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const backendDir = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(backendDir, '..');
+const outDir = path.resolve(repoRoot, 'httpdocs');
+
+const BASE_URL = process.env.PUBLIC_BASE_URL || 'https://winove.com.br';
+
+function buildUrlset(urls) {
+  const items = urls
+    .map(({ loc, lastmod }) =>
+      `  <url>\n    <loc>${loc}</loc>${lastmod ? `\n    <lastmod>${lastmod}</lastmod>` : ''}\n  </url>`
+    )
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${items}\n</urlset>\n`;
+}
+
+async function fetchPostUrls() {
+  const [rows] = await pool.query(
+    'SELECT slug, data_publicacao AS date FROM blog_posts ORDER BY data_publicacao DESC'
+  );
+  return rows.map((r) => ({
+    loc: `${BASE_URL}/blog/${r.slug}`,
+    lastmod: r.date ? new Date(r.date).toISOString() : undefined,
+  }));
+}
+
+async function main() {
+  const staticUrls = ['/', '/blog', '/cases'].map((p) => ({
+    loc: `${BASE_URL}${p}`,
+  }));
+
+  const posts = await fetchPostUrls();
+
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(path.join(outDir, 'sitemap.xml'), buildUrlset(staticUrls));
+  await fs.writeFile(path.join(outDir, 'post-sitemap.xml'), buildUrlset(posts));
+
+  const index =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    ['sitemap.xml', 'post-sitemap.xml']
+      .map((f) => `  <sitemap>\n    <loc>${BASE_URL}/${f}</loc>\n  </sitemap>`)
+      .join('\n') +
+    `\n</sitemapindex>\n`;
+  await fs.writeFile(path.join(outDir, 'sitemap_index.xml'), index);
+
+  console.log(`Sitemaps generated in ${outDir}`);
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error('Failed to generate sitemaps:', err);
+  process.exit(1);
+});
+

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -17,3 +17,7 @@ cp -r "$FRONTEND_DIR/dist" "$BACKEND_DIR/"
 
 echo "Frontend build copied to backend/dist"
 
+# Generate sitemaps
+npm --prefix "$BACKEND_DIR" run sitemap
+echo "Sitemaps generated in httpdocs/"
+


### PR DESCRIPTION
## Summary
- generate sitemap, post-sitemap and index files from database
- add npm script for sitemap generation
- run sitemap generation during deploy

## Testing
- `npm --prefix backend run sitemap` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a7216f188330af50d0c39f55ddff