### PR TITLE
feat: add sitemap generation script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "prestart": "node scripts/build-and-sync.mjs",
     "migrate": "node scripts/migrate.mjs",
     "start": "node index.js",
-    "deploy": "bash ../deploy/deploy.sh"
+    "deploy": "bash ../deploy/deploy.sh",
+    "sitemap": "node scripts/generate-sitemap.mjs"
   },
   "dependencies": {
     "axios": "^1.11.0",

--- a/backend/scripts/generate-sitemap.mjs
+++ b/backend/scripts/generate-sitemap.mjs
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+import axios from 'axios';
+import { SitemapStream, streamToPromise } from 'sitemap';
+import { gzipSync } from 'node:zlib';
+import { fileURLToPath } from 'url';
+
+async function generate() {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const rootDir = path.resolve(__dirname, '..');
+  const httpdocsDir = path.resolve(rootDir, '..', 'httpdocs');
+
+  const { data: posts } = await axios.get('https://winove.com.br/api/blog-posts', { proxy: false });
+
+  const postUrls = posts.map((post) => ({
+    url: `/blog/${post.slug}`,
+    changefreq: 'weekly',
+    priority: 0.7,
+    lastmodISO: post.date,
+  }));
+
+  const smStream = new SitemapStream({ hostname: 'https://winove.com.br' });
+
+  smStream.write({ url: '/', changefreq: 'weekly', priority: 1.0 });
+  smStream.write({ url: '/blog', changefreq: 'weekly', priority: 0.8 });
+  smStream.write({ url: '/sobre', changefreq: 'monthly', priority: 0.6 });
+  smStream.write({ url: '/servicos', changefreq: 'monthly', priority: 0.6 });
+  smStream.write({ url: '/contato', changefreq: 'monthly', priority: 0.6 });
+
+  postUrls.forEach((page) => smStream.write(page));
+
+  smStream.end();
+  const data = await streamToPromise(smStream);
+
+  await fs.promises.mkdir(httpdocsDir, { recursive: true });
+  await fs.promises.writeFile(path.join(httpdocsDir, 'sitemap.xml'), data.toString());
+  await fs.promises.writeFile(path.join(httpdocsDir, 'sitemap.xml.gz'), gzipSync(data));
+
+  console.log('Sitemap written to httpdocs/');
+}
+
+generate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- generate sitemap files from backend
- expose script for deployment

## Testing
- `npm --prefix backend run sitemap` *(fails: connect ENETUNREACH 168.75.84.128:443)*
- `bash deploy/deploy.sh` *(fails: connect ENETUNREACH 168.75.84.128:443)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c6b539608330a003f5f7fe5bc1ee