### PR TITLE
feat: add navigation hooks to 404 page

### DIFF
--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,8 +1,9 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     console.error(
@@ -16,9 +17,32 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+        <div className="flex flex-col gap-2">
+          <button
+            onClick={() => navigate("/")}
+            className="text-blue-500 hover:text-blue-700 underline"
+          >
+            Ir para Home
+          </button>
+          <button
+            onClick={() => navigate("/templates")}
+            className="text-blue-500 hover:text-blue-700 underline"
+          >
+            Ir para Templates
+          </button>
+          <button
+            onClick={() => navigate("/blog")}
+            className="text-blue-500 hover:text-blue-700 underline"
+          >
+            Ir para Blog
+          </button>
+          <button
+            onClick={() => navigate("/cases")}
+            className="text-blue-500 hover:text-blue-700 underline"
+          >
+            Ir para Cases
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use `useNavigate` hook to add navigation options to 404 page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68b5b5fbe0ec833095ee88cc81d79702