### PR TITLE
feat: redesign 404 page with navigation cards

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,19 +1,34 @@
 import axios from 'axios';
 
+export interface Template {
+  slug: string;
+  category?: string;
+  difficulty?: string;
+  title: string;
+  description?: string;
+  tags?: string[];
+  images: {
+    cover: string;
+  };
+  price: number;
+  originalPrice?: number;
+  pages?: number;
+}
+
 // In Vite, env vars come from import.meta.env
-const BASE_URL = (import.meta as any).env?.VITE_API_URL || '';
+const BASE_URL = import.meta.env.VITE_API_URL || '';
 
 export const api = axios.create({
   baseURL: BASE_URL, // empty -> use same-origin relative /api
   timeout: 5000,
 });
 
-export const fetchTemplate = async (slug: string) => {
-  const res = await api.get(`/api/templates/${slug}`);
+export const fetchTemplate = async (slug: string): Promise<Template> => {
+  const res = await api.get<Template>(`/api/templates/${slug}`);
   return res.data;
 };
 
-export const fetchTemplates = async () => {
-  const res = await api.get(`/api/templates`);
+export const fetchTemplates = async (): Promise<Template[]> => {
+  const res = await api.get<Template[]>(`/api/templates`);
   return res.data;
 };

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,8 +1,48 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface ActionCard {
+  title: string;
+  description: string;
+  path: string;
+}
+
+const actions: ActionCard[] = [
+  {
+    title: "Voltar para Home",
+    description: "Visite a página inicial e descubra nossos serviços.",
+    path: "/",
+  },
+  {
+    title: "Explorar Templates",
+    description: "Veja nossos modelos personalizados para seu negócio.",
+    path: "/templates",
+  },
+  {
+    title: "Ler o Blog",
+    description: "Confira artigos e novidades no nosso blog.",
+    path: "/blog",
+  },
+  {
+    title: "Ver Cases",
+    description: "Conheça os cases de sucesso de nossos clientes.",
+    path: "/cases",
+  },
+];
 
 const NotFound = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     console.error(
@@ -12,14 +52,28 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
-      </div>
+    <div className="min-h-screen bg-background text-foreground flex flex-col font-inter">
+      <Header />
+      <main className="flex-grow container mx-auto px-4 flex flex-col items-center justify-center py-24">
+        <h1 className="text-5xl font-bold mb-4">404</h1>
+        <p className="text-xl text-muted-foreground mb-8 text-center">
+          Ops! A página que você procura não foi encontrada.
+        </p>
+        <div className="grid gap-6 w-full max-w-4xl md:grid-cols-2">
+          {actions.map((action) => (
+            <Card key={action.path}>
+              <CardHeader>
+                <CardTitle>{action.title}</CardTitle>
+                <CardDescription>{action.description}</CardDescription>
+              </CardHeader>
+              <CardFooter>
+                <Button onClick={() => navigate(action.path)}>Ir</Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </main>
+      <Footer />
     </div>
   );
 };

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -7,30 +7,40 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Link } from "react-router-dom";
 import { useQuery } from '@tanstack/react-query';
-import { fetchTemplates } from '@/lib/api';
+import { fetchTemplates, Template } from '@/lib/api';
 import { Search, Eye, Star, Filter } from "lucide-react";
 
 const Templates = () => {
   const [selectedCategory, setSelectedCategory] = useState("Todos");
   const [searchTerm, setSearchTerm] = useState("");
 
-  const { data: templates = [], isLoading } = useQuery({ queryKey: ['templates'], queryFn: fetchTemplates });
+  const { data: templates = [], isLoading } = useQuery<Template[]>({
+    queryKey: ['templates'],
+    queryFn: fetchTemplates,
+  });
 
   // Build dynamic category list from API data
   const categories = useMemo(() => {
     const set = new Set<string>();
-    (templates || []).forEach((t: any) => {
-      const c = (t?.category || "").toString().trim();
+    templates.forEach((t) => {
+      const c = (t.category || "").toString().trim();
       if (c) set.add(c);
     });
     return ["Todos", ...Array.from(set)];
   }, [templates]);
 
-  const filteredTemplates = templates.filter((template: any) => {
-    const matchesCategory = selectedCategory === "Todos" || (template.category || '').toLowerCase() === selectedCategory.toLowerCase();
-    const matchesSearch = template.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         (template.description || '').toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         (template.tags || []).some((tag: string) => tag.toLowerCase().includes(searchTerm.toLowerCase()));
+  const filteredTemplates = templates.filter((template) => {
+    const matchesCategory =
+      selectedCategory === "Todos" ||
+      (template.category || '').toLowerCase() === selectedCategory.toLowerCase();
+    const matchesSearch =
+      template.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (template.description || '')
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase()) ||
+      (template.tags || []).some((tag) =>
+        tag.toLowerCase().includes(searchTerm.toLowerCase())
+      );
     return matchesCategory && matchesSearch;
   });
 
@@ -98,7 +108,7 @@ const Templates = () => {
             {isLoading ? (
               <div>Carregando templates...</div>
             ) : (
-              filteredTemplates.map((template: any) => {
+              filteredTemplates.map((template) => {
                 return (
                   <Card key={template.slug} className="group hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20">
                     <CardHeader className="p-0">


### PR DESCRIPTION
## Summary
- redesign 404 page with card-based layout and navigation options
- define Template interface and remove `any` usage to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5b5fbe0ec833095ee88cc81d79702