### PR TITLE
feat: add libras service landing and lead capture

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -10,6 +10,7 @@ import blogPostsRoute from './routes/blogPosts.js';
 import casesRoute from './routes/cases.js';
 import templatesRoute from './routes/templates.js';
 import sitemapRoute from './routes/sitemap.js';
+import leadsRoutes from './routes/leads.js';
 
 // Env vars
 dotenv.config();
@@ -47,6 +48,7 @@ app.use((_req, res, next) => {
 app.use('/api/blog-posts', blogPostsRoute);
 app.use('/api/cases', casesRoute);
 app.use('/api/templates', templatesRoute);
+app.use('/api/leads', leadsRoutes);
 app.use('/', sitemapRoute);
 
 // Health check

--- a/backend/leads_libras.sql
+++ b/backend/leads_libras.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS leads_libras (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nome VARCHAR(150) NOT NULL,
+  email VARCHAR(200) NOT NULL,
+  telefone VARCHAR(50),
+  empresa VARCHAR(200),
+  tipoServico VARCHAR(50),
+  dataEvento DATE,
+  local_evento VARCHAR(200),
+  tamanhoPublico VARCHAR(50),
+  duracao VARCHAR(50),
+  linkVideo TEXT,
+  descricao TEXT,
+  lgpdConsent TINYINT(1) DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/routes/leads.js
+++ b/backend/routes/leads.js
@@ -1,0 +1,53 @@
+import { Router } from "express";
+import mysql from "mysql2/promise";
+import dotenv from "dotenv";
+dotenv.config();
+
+const router = Router();
+
+async function getConnection() {
+  return await mysql.createConnection({
+    host: 'lweb03.appuni.com.br',
+    port: 3306,
+    user: 'winove',
+    password: '9*19avmU0',
+    database: 'fernando_winove_com_br_'
+  });
+}
+
+router.post("/libras", async (req, res) => {
+  try {
+    const hp = req.body?.hp_field?.trim();
+    if (hp) return res.status(200).json({ ok: true });
+
+    const {
+      nome, email, telefone, empresa,
+      tipoServico, dataEvento, local: local_evento,
+      tamanhoPublico, duracao, linkVideo, descricao,
+      lgpdConsent
+    } = req.body || {};
+
+    if (!nome || !email) return res.status(400).json({ error: "nome e email são obrigatórios" });
+
+    const conn = await getConnection();
+    await conn.execute(
+      `INSERT INTO leads_libras 
+       (nome, email, telefone, empresa, tipoServico, dataEvento, local_evento, tamanhoPublico, duracao, linkVideo, descricao, lgpdConsent)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        nome, email, telefone || null, empresa || null,
+        tipoServico || null, dataEvento || null, local_evento || null,
+        tamanhoPublico || null, duracao || null, linkVideo || null,
+        descricao || null, lgpdConsent ? 1 : 0
+      ]
+    );
+    await conn.end();
+
+    res.json({ ok: true });
+  } catch (err) {
+    console.error("POST /api/leads/libras error:", err);
+    res.status(500).json({ error: "internal_error" });
+  }
+});
+
+export default router;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import ChatWhatsapp from "@/pages/ChatWhatsapp";
 import { CentralAtendimento } from "@/pages/CentralAtendimento";
 import Promocoes from "./pages/Promocoes";
 import NotFound from "./pages/NotFound";
+import LibrasPage from "./pages/Libras";
 
 const queryClient = new QueryClient();
 
@@ -45,6 +46,7 @@ const App = () => (
           <Route path="/payment-success" element={<PaymentSuccess />} />
           <Route path="/payment-canceled" element={<PaymentCanceled />} />
           <Route path="/admin" element={<Admin />} />
+          <Route path="/servicos/libras" element={<LibrasPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -30,6 +30,8 @@ export const Header = () => {
   const navItems: NavItem[] = [
     { name: "Início", href: "/", type: "link" },
     { name: "Serviços", href: "#services", type: "anchor" },
+    { name: "Libras", href: "/servicos/libras", type: "link" },
+    { name: "Conteúdos Gravados (Janela)", href: "/servicos/libras#orcamento", type: "link" },
     { name: "Templates", href: "/templates", type: "link" },
     { name: "E-mail Corporativo", href: "/email-corporativo", type: "link" },
 

--- a/frontend/src/components/forms/LibrasLeadForm.tsx
+++ b/frontend/src/components/forms/LibrasLeadForm.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+type Props = { onSuccess?: () => void };
+
+export function LibrasLeadForm({ onSuccess }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [hp, setHp] = useState(""); // honeypot
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (hp) return; // bot
+
+    const form = new FormData(e.currentTarget);
+    const payload = Object.fromEntries(form.entries());
+
+    setLoading(true);
+    try {
+      const res = await fetch("/api/leads/libras", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("Erro ao enviar");
+      onSuccess?.();
+      (e.currentTarget as HTMLFormElement).reset();
+      window.gtag?.("event", "lead_submit", { service: "libras" });
+    } catch (err) {
+      alert("Não foi possível enviar. Tente novamente.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        name="hp_field"
+        value={hp}
+        onChange={(e) => setHp(e.target.value)}
+        className="hidden"
+        tabIndex={-1}
+        autoComplete="off"
+      />
+      <div className="grid sm:grid-cols-2 gap-4">
+        <input required name="nome" placeholder="Seu nome*" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+        <input required type="email" name="email" placeholder="E-mail corporativo*" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+        <input name="telefone" placeholder="Telefone/WhatsApp" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+        <input name="empresa" placeholder="Empresa" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        <select name="tipoServico" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800">
+          <option value="Presencial SP">Presencial (São Paulo)</option>
+          <option value="Gravado/Janela">Conteúdos gravados (janela de Libras)</option>
+        </select>
+        <input type="date" name="dataEvento" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        <input name="local" placeholder="Local do evento (se presencial)" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+        <input name="tamanhoPublico" placeholder="Público estimado (ex.: 200)" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        <input name="duracao" placeholder="Duração prevista (ex.: 2h)" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+        <input name="linkVideo" placeholder="Link do vídeo (se conteúdo gravado)" className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800" />
+      </div>
+
+      <textarea name="descricao" placeholder="Conte mais sobre o evento/vídeo"
+        className="w-full px-4 py-3 rounded-xl bg-neutral-900 border border-neutral-800 min-h-[120px]" />
+
+      <label className="flex items-start gap-2 text-sm text-neutral-300">
+        <input required type="checkbox" name="lgpdConsent" className="mt-1" />
+        Autorizo o contato para fins de orçamento, conforme LGPD.
+      </label>
+
+      <button disabled={loading}
+        className="px-5 py-3 bg-orange-500 hover:bg-orange-600 rounded-xl font-semibold disabled:opacity-60">
+        {loading ? "Enviando..." : "Solicitar orçamento"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { LibrasLeadForm } from "@/components/forms/LibrasLeadForm";
+
+export default function LibrasPage() {
+  const [sent, setSent] = useState(false);
+
+  useEffect(() => {
+    document.title = "Interpretação de Libras em SP e Janela de Libras para Vídeos | Winove";
+    const metaDesc = "Cobertura presencial em São Paulo e janela de Libras para vídeos. Equipes certificadas, NBR 15290 e revezamento para eventos >1h. Proposta em até 24h.";
+    let meta = document.querySelector("meta[name='description']");
+    if (!meta) {
+      meta = document.createElement("meta");
+      meta.setAttribute("name", "description");
+      document.head.appendChild(meta);
+    }
+    meta.setAttribute("content", metaDesc);
+
+    const script = document.createElement("script");
+    script.type = "application/ld+json";
+    script.text = JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "name": "Interpretação de Libras (SP) e Janela de Libras para Vídeos",
+      "provider": { "@type": "Organization", "name": "Winove" },
+      "areaServed": { "@type": "AdministrativeArea", "name": "São Paulo" },
+      "serviceType": "Libras Presencial; Janela de Libras",
+      "offers": { "@type": "Offer", "availability": "https://schema.org/InStock" },
+      "audience": { "@type": "Audience", "audienceType": ["Empresas", "Palestrantes", "Produtoras"] },
+      "hasOfferCatalog": {
+        "@type": "OfferCatalog",
+        "name": "Formatos",
+        "itemListElement": [
+          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Presencial (SP)" } },
+          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Conteúdos gravados (Janela de Libras)" } }
+        ]
+      }
+    });
+    document.head.appendChild(script);
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-neutral-950 text-neutral-100">
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 opacity-30 bg-gradient-to-br from-orange-500/20 via-amber-400/10 to-white/0" />
+        <div className="container mx-auto px-6 py-20 relative">
+          <div className="max-w-3xl">
+            <h1 className="text-4xl md:text-5xl font-extrabold leading-tight">
+              Interpretação de Libras <span className="text-orange-400">SP presencial</span> & <span className="text-orange-400">conteúdos gravados</span>
+            </h1>
+            <p className="mt-5 text-lg text-neutral-300">
+              Aumente alcance, cumpra a legislação e entregue experiências verdadeiramente inclusivas.
+            </p>
+            <div className="mt-8 flex gap-3">
+              <a href="#orcamento" className="px-5 py-3 bg-orange-500 hover:bg-orange-600 rounded-xl font-semibold">
+                Solicitar orçamento
+              </a>
+              <a
+                href="https://wa.me/5511999999999?text=Quero%20or%C3%A7amento%20de%20interpreta%C3%A7%C3%A3o%20em%20Libras&utm_source=site&utm_medium=cta&utm_campaign=libras"
+                className="px-5 py-3 border border-neutral-700 hover:border-neutral-500 rounded-xl"
+                target="_blank" rel="noopener noreferrer"
+              >
+                Falar no WhatsApp
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="container mx-auto px-6 py-16 grid md:grid-cols-2 gap-10">
+        <div>
+          <h2 className="text-2xl font-bold">Por que contratar</h2>
+          <ul className="mt-4 space-y-3 text-neutral-300">
+            <li>• Cobertura presencial na região de São Paulo.</li>
+            <li>• Janela de Libras para vídeos conforme NBR 15290.</li>
+            <li>• Escala de intérpretes e revezamento para &gt; 1h.</li>
+            <li>• Briefing, glossário, ensaio e QA.</li>
+            <li>• Compliance, NF e contratos.</li>
+          </ul>
+        </div>
+        <div className="rounded-2xl border border-neutral-800 p-6 bg-neutral-900/50">
+          <h3 className="font-semibold">Formatos</h3>
+          <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="p-4 rounded-xl bg-neutral-900 border border-neutral-800">
+              <div className="text-orange-400 font-semibold">Presencial (SP)</div>
+              <p className="text-sm text-neutral-300 mt-2">Palestras, convenções, treinamentos, lançamentos.</p>
+            </div>
+            <div className="p-4 rounded-xl bg-neutral-900 border border-neutral-800">
+              <div className="text-orange-400 font-semibold">Conteúdos gravados</div>
+              <p className="text-sm text-neutral-300 mt-2">Janela de Libras para vídeos, EAD, institucionais.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="container mx-auto px-6 py-16">
+        <div className="rounded-2xl border border-neutral-800 p-6 bg-neutral-900/50">
+          <h2 className="text-2xl font-bold">Como funciona</h2>
+          <ol className="mt-4 space-y-3 text-neutral-300">
+            <li>1) Briefing do evento ou vídeo</li>
+            <li>2) Proposta (escopo, escala, custos e prazos)</li>
+            <li>3) Execução (presencial ou estúdio/janela)</li>
+            <li>4) QA NBR 15290</li>
+            <li>5) Entrega + pós-evento</li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="orcamento" className="container mx-auto px-6 py-16">
+        <div className="grid lg:grid-cols-2 gap-10">
+          <div>
+            <h2 className="text-2xl font-bold">Solicite um orçamento</h2>
+            <p className="mt-2 text-neutral-300">Retornamos com proposta em até 24 horas úteis.</p>
+            <div className="mt-6">
+              <LibrasLeadForm onSuccess={() => setSent(true)} />
+              {sent && (
+                <p className="mt-3 text-green-400">
+                  Recebemos seu pedido! Entraremos em contato em breve.
+                </p>
+              )}
+            </div>
+          </div>
+          <aside className="rounded-2xl border border-neutral-800 p-6 bg-neutral-900/50">
+            <h3 className="font-semibold">Requisitos & Compliance</h3>
+            <ul className="mt-3 text-sm text-neutral-300 space-y-2">
+              <li>• NBR 15290 (janela de Libras para vídeos)</li>
+              <li>• Revezamento para atividades &gt; 1h (Lei 14.704/2023)</li>
+              <li>• Plano de contingência (intérprete backup quando aplicável)</li>
+              <li>• Dress code, contraste e enquadramento para melhor legibilidade</li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Libras service landing page and form with tracking
- store Libras leads via new API route and MySQL table script
- link Libras page in navigation

## Testing
- `cd frontend && npm test`
- `npm run lint`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02f9aa2908330ad9f96fd7f89dcc5