### PR TITLE
Add subtle background video to Libras page

### DIFF
--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -15,6 +15,12 @@ export default function LibrasPage() {
     }
     meta.setAttribute("content", metaDesc);
 
+    const robots = document.createElement("meta");
+    robots.setAttribute("name", "robots");
+    robots.setAttribute("content", "noindex");
+    robots.setAttribute("data-page", "libras");
+    document.head.appendChild(robots);
+
     const script = document.createElement("script");
     script.type = "application/ld+json";
     script.text = JSON.stringify({
@@ -38,12 +44,23 @@ export default function LibrasPage() {
     document.head.appendChild(script);
     return () => {
       document.head.removeChild(script);
+      document.head.removeChild(robots);
     };
   }, []);
 
   return (
     <main className="min-h-screen bg-neutral-950 text-neutral-100">
       <section className="relative overflow-hidden">
+        <video
+          className="absolute inset-0 w-full h-full object-cover opacity-20"
+          autoPlay
+          loop
+          muted
+          playsInline
+          aria-hidden="true"
+        >
+          <source src="/assets/1741273281128%20(1).mp4" type="video/mp4" />
+        </video>
         <div className="absolute inset-0 opacity-30 bg-gradient-to-br from-orange-500/20 via-amber-400/10 to-white/0" />
         <div className="container mx-auto px-6 py-20 relative">
           <div className="max-w-3xl">


### PR DESCRIPTION
## Summary
- Add obscured looping background video to Libras hero section
- Insert temporary robots noindex meta tag so the page isn't indexed when the video loads

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c035ffb6688330a9c0adb4a0281100