### PR TITLE
fix: prevent header overlap and add Libras video

### DIFF
--- a/frontend/src/pages/BlogList.tsx
+++ b/frontend/src/pages/BlogList.tsx
@@ -68,9 +68,9 @@ export const BlogList = () => {
   const postsToShow = filteredPosts.slice(0, visibleCount);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pt-24">
       {/* Hero Section */}
-      <section className="pt-24 pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/BlogPost.tsx
+++ b/frontend/src/pages/BlogPost.tsx
@@ -61,8 +61,8 @@ export const BlogPost = () => {
 
   if (!post) {
     return (
-      <div className="min-h-screen bg-background">
-        <div className="pt-24 pb-16">
+      <div className="min-h-screen bg-background pt-24">
+        <div className="pb-16">
           <div className="container mx-auto px-4">
             <div className="max-w-4xl mx-auto text-center">
               <h1 className="text-4xl font-bold text-foreground mb-4">Post não encontrado</h1>
@@ -79,9 +79,9 @@ export const BlogPost = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pt-24">
       {/* Hero Section */}
-      <section className="pt-24 pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/CasesList.tsx
+++ b/frontend/src/pages/CasesList.tsx
@@ -32,9 +32,9 @@ export const CasesList = () => {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pt-24">
       {/* Hero Section */}
-      <section className="pt-24 pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/EmailCorporativo.tsx
+++ b/frontend/src/pages/EmailCorporativo.tsx
@@ -22,9 +22,9 @@ const EmailCorporativo = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-background text-foreground pt-24">
       {/* Hero Section */}
-      <section className="pt-24 pb-16 px-4 bg-gradient-to-br from-primary/5 via-background to-primary/5">
+      <section className="pb-16 px-4 bg-gradient-to-br from-primary/5 via-background to-primary/5">
         <div className="container mx-auto text-center">
           <Badge className="mb-4 px-4 py-2">Email Profissional</Badge>
           <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">

--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -49,8 +49,8 @@ export default function LibrasPage() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-neutral-950 text-neutral-100">
-      <section className="relative overflow-hidden pt-24">
+    <main className="min-h-screen bg-neutral-950 text-neutral-100 pt-24">
+      <section className="relative overflow-hidden">
         <video
           className="absolute inset-0 w-full h-full object-cover opacity-20"
           autoPlay
@@ -59,7 +59,7 @@ export default function LibrasPage() {
           playsInline
           aria-hidden="true"
         >
-          <source src="/assets/1741273281128%20(1).mp4" type="video/mp4" />
+          <source src="/assets/1741273281128%20%281%29.mp4" type="video/mp4" />
         </video>
         <div className="absolute inset-0 opacity-30 bg-gradient-to-br from-orange-500/20 via-amber-400/10 to-white/0" />
         <div className="container mx-auto px-6 py-20 relative">

--- a/frontend/src/pages/Promocoes.tsx
+++ b/frontend/src/pages/Promocoes.tsx
@@ -23,8 +23,8 @@ const Promocoes = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <section className="pt-24 pb-16 px-4">
+    <div className="min-h-screen bg-background text-foreground pt-24">
+      <section className="pb-16 px-4">
         <div className="container mx-auto text-center">
           <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
             Promoções do Mês

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -44,9 +44,9 @@ const Templates = () => {
   });
 
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-background text-foreground pt-24">
       {/* Hero Section */}
-      <section className="pt-24 pb-16 px-4">
+      <section className="pb-16 px-4">
         <div className="container mx-auto text-center">
           <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
             Templates Wix Studio


### PR DESCRIPTION
## Summary
- offset interior pages so first section isn't hidden beneath fixed header
- reference existing Libras hero video asset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04108176c8330b944d52535fe236c