### PR TITLE
feat: improve sticky header and spacing

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,10 +12,10 @@ type NavItem = {
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const location = useLocation();
-  const ref = useRef<HTMLElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
-    const el = ref.current;
+    const el = headerRef.current;
     if (!el) return;
     const root = document.documentElement;
     const setVars = () => {
@@ -52,9 +52,9 @@ export const Header = () => {
   return (
     <>
     <header
-      ref={ref}
       id="site-header"
-      className="w-full border-b border-border/20 z-50"
+      ref={headerRef}
+      className="sticky top-0 z-50 w-full border-b border-border bg-background/90 backdrop-blur"
     >
       {/* Faixa superior */}
       <div className="bg-primary text-primary-foreground text-sm flex items-center justify-center py-1">

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -9,7 +9,10 @@ type HeroProps = {
 
 export const Hero = ({ heading, subheading }: HeroProps) => {
   return (
-    <section id="hero" className="group min-h-screen pt-24 pb-16 flex items-center justify-center relative overflow-hidden">
+    <section
+      id="hero"
+      className="section--first px-4 py-16 group min-h-screen flex items-center justify-center relative overflow-hidden"
+    >
       {/* Background Image */}
       <div
         className="absolute inset-0 bg-cover bg-center bg-no-repeat"
@@ -27,7 +30,7 @@ export const Hero = ({ heading, subheading }: HeroProps) => {
       </div>
 
       {/* Content */}
-      <div className="container mx-auto px-4 relative z-10">
+      <div className="container mx-auto relative z-10">
         <div className="max-w-4xl mx-auto text-center">
           <h1 className="text-4xl md:text-6xl font-extrabold mb-6 animate-fade-in-up leading-tight transition-transform duration-300 group-hover:scale-[1.02]">
             <span className="bg-gradient-to-r from-primary to-primary/80 bg-clip-text text-transparent">{heading || 'Winove, Sua ideia online'}</span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -139,6 +139,23 @@
   body {
     @apply bg-background text-foreground font-inter overflow-x-hidden;
   }
+
+  /* Sticky header spacing and offsets */
+  .has-sticky-header body,
+  .has-sticky-header main,
+  .has-sticky-header #app {
+    padding-top: calc(var(--header-h) + var(--content-gap));
+  }
+
+  [id],
+  section,
+  .section {
+    scroll-margin-top: calc(var(--header-h) + var(--content-gap));
+  }
+
+  .section--first {
+    padding-top: var(--content-gap);
+  }
 }
 
 @layer components {
@@ -255,28 +272,4 @@
   .bg-glass {
     background-color: var(--glass-bg);
   }
-}
-
-/* Sticky header spacing and offsets */
-.has-sticky-header body,
-.has-sticky-header main,
-.has-sticky-header #app {
-  padding-top: calc(var(--header-h) + var(--content-gap));
-}
-
-[id], section, .section {
-  scroll-margin-top: calc(var(--header-h) + var(--content-gap));
-}
-
-.page-first, .section--first {
-  padding-top: var(--content-gap);
-}
-
-#site-header {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  backdrop-filter: saturate(180%) blur(8px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(15, 15, 15, 0.92);
 }


### PR DESCRIPTION
## Summary
- ensure header remains sticky and sets height CSS variables
- add global padding offsets and section spacing
- use section--first on hero to avoid overlap with header

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c04811e690833098b6ed628a89126c