### PR TITLE
Remove extra top padding after header

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -11,7 +11,7 @@ export const Hero = ({ heading, subheading }: HeroProps) => {
   return (
     <section
       id="hero"
-      className="section--first px-4 py-16 group min-h-screen flex items-center justify-center relative overflow-hidden"
+      className="section--first px-4 pb-16 group min-h-screen relative overflow-hidden"
     >
       {/* Background Image */}
       <div

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -144,17 +144,17 @@
   .has-sticky-header body,
   .has-sticky-header main,
   .has-sticky-header #app {
-    padding-top: calc(var(--header-h) + var(--content-gap));
+    padding-top: 0;
   }
 
   [id],
   section,
   .section {
-    scroll-margin-top: calc(var(--header-h) + var(--content-gap));
+    scroll-margin-top: var(--header-h);
   }
 
   .section--first {
-    padding-top: var(--content-gap);
+    padding-top: var(--header-h);
   }
 }
 

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -208,7 +208,7 @@ export const Admin = () => {
   if (!isAuthenticated) {
     return (
       <div className="min-h-screen bg-background">
-        <div className="pt-24 pb-16">
+        <div className="section--first pb-16">
           <div className="container mx-auto px-4">
             <div className="max-w-md mx-auto">
               <Card>
@@ -244,7 +244,7 @@ export const Admin = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <div className="pt-24 pb-16">
+      <div className="section--first pb-16">
         <div className="container mx-auto px-4">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">

--- a/frontend/src/pages/BlogList.tsx
+++ b/frontend/src/pages/BlogList.tsx
@@ -68,9 +68,9 @@ export const BlogList = () => {
   const postsToShow = filteredPosts.slice(0, visibleCount);
 
   return (
-    <div className="min-h-screen bg-background pt-24">
+    <div className="min-h-screen bg-background">
       {/* Hero Section */}
-      <section className="pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="section--first pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/BlogPost.tsx
+++ b/frontend/src/pages/BlogPost.tsx
@@ -61,8 +61,8 @@ export const BlogPost = () => {
 
   if (!post) {
     return (
-      <div className="min-h-screen bg-background pt-24">
-        <div className="pb-16">
+      <div className="min-h-screen bg-background">
+        <div className="section--first pb-16">
           <div className="container mx-auto px-4">
             <div className="max-w-4xl mx-auto text-center">
               <h1 className="text-4xl font-bold text-foreground mb-4">Post não encontrado</h1>
@@ -79,9 +79,9 @@ export const BlogPost = () => {
   }
 
   return (
-    <div className="min-h-screen bg-background pt-24">
+    <div className="min-h-screen bg-background">
       {/* Hero Section */}
-      <section className="pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="section--first pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -51,7 +51,7 @@ export const CaseDetail = () => {
   if (!caseItem) {
     return (
       <div className="min-h-screen bg-background">
-        <div className="pt-24 pb-16">
+        <div className="section--first pb-16">
           <div className="container mx-auto px-4">
             <div className="max-w-4xl mx-auto text-center">
               <h1 className="text-4xl font-bold text-foreground mb-4">Case não encontrado</h1>
@@ -69,7 +69,7 @@ export const CaseDetail = () => {
   return (
     <div className="min-h-screen bg-background">
       {/* Hero Section */}
-      <section className="pt-24 pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="section--first pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/CasesList.tsx
+++ b/frontend/src/pages/CasesList.tsx
@@ -32,9 +32,9 @@ export const CasesList = () => {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background pt-24">
+    <div className="min-h-screen bg-background">
       {/* Hero Section */}
-      <section className="pb-16 bg-gradient-navy relative overflow-hidden">
+      <section className="section--first pb-16 bg-gradient-navy relative overflow-hidden">
         <div className="absolute inset-0 overflow-hidden">
           <div className="absolute top-0 right-1/4 w-72 h-72 bg-primary/8 rounded-full blur-3xl animate-float" />
           <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-primary/5 rounded-full blur-3xl" style={{ animationDelay: '4s' }} />

--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -49,8 +49,8 @@ export default function LibrasPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-neutral-950 text-neutral-100 pt-24">
-      <section className="relative overflow-hidden">
+    <div className="min-h-screen bg-neutral-950 text-neutral-100">
+      <section className="section--first relative overflow-hidden">
         <video
           className="absolute inset-0 w-full h-full object-cover opacity-20"
           autoPlay

--- a/frontend/src/pages/PaymentCanceled.tsx
+++ b/frontend/src/pages/PaymentCanceled.tsx
@@ -7,7 +7,7 @@ import { XCircle, ArrowLeft, ShoppingCart, MessageCircle } from "lucide-react";
 const PaymentCanceled = () => {
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="pt-24 px-4 pb-16">
+      <div className="section--first px-4 pb-16">
         <div className="container mx-auto max-w-2xl">
           <Card className="text-center">
             <CardHeader className="pb-6">

--- a/frontend/src/pages/PaymentSuccess.tsx
+++ b/frontend/src/pages/PaymentSuccess.tsx
@@ -7,7 +7,7 @@ import { CheckCircle, Download, ArrowLeft, Mail } from "lucide-react";
 const PaymentSuccess = () => {
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="pt-24 px-4 pb-16">
+      <div className="section--first px-4 pb-16">
         <div className="container mx-auto max-w-2xl">
           <Card className="text-center">
             <CardHeader className="pb-6">

--- a/frontend/src/pages/Promocoes.tsx
+++ b/frontend/src/pages/Promocoes.tsx
@@ -23,8 +23,8 @@ const Promocoes = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-background text-foreground pt-24">
-      <section className="pb-16 px-4">
+    <div className="min-h-screen bg-background text-foreground">
+      <section className="section--first pb-16 px-4">
         <div className="container mx-auto text-center">
           <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
             Promoções do Mês

--- a/frontend/src/pages/TemplateDetail.tsx
+++ b/frontend/src/pages/TemplateDetail.tsx
@@ -30,7 +30,7 @@ const TemplateDetail = () => {
 
   // Inline skeleton to manter layout enquanto carrega
   const DetailSkeleton = () => (
-    <div className="pt-24 px-4">
+    <div className="section--first px-4">
       <div className="container mx-auto">
         <div className="h-6 w-40 bg-muted/40 rounded mb-6 animate-pulse" />
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -69,7 +69,7 @@ const TemplateDetail = () => {
   if (!template) {
     return (
       <div className="min-h-screen bg-background text-foreground">
-        <div className="pt-24 px-4">
+        <div className="section--first px-4">
           <div className="container mx-auto text-center py-16">
             <h1 className="text-2xl font-bold mb-4">Template não encontrado</h1>
             <Link to="/templates">
@@ -115,7 +115,7 @@ const TemplateDetail = () => {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="pt-24 px-4">
+      <div className="section--first px-4">
         <div className="container mx-auto">
           {/* Breadcrumb */}
           <div className="mb-6">

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -44,9 +44,9 @@ const Templates = () => {
   });
 
   return (
-    <div className="min-h-screen bg-background text-foreground pt-24">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Hero Section */}
-      <section className="pb-16 px-4">
+      <section className="section--first pb-16 px-4">
         <div className="container mx-auto text-center">
           <h1 className="text-4xl md:text-6xl font-bold mb-6 bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
             Templates Wix Studio


### PR DESCRIPTION
## Summary
- eliminate global top padding and compute first-section offset using header height
- update hero and page sections so content starts immediately after the header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04de0339483308e539def78941fe0