### PR TITLE
feat: center first section content across pages

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -155,6 +155,7 @@
 
   .section--first {
     padding-top: var(--header-h);
+    @apply min-h-[60vh] flex items-center justify-center;
   }
 }
 

--- a/frontend/src/pages/CentralAtendimento.tsx
+++ b/frontend/src/pages/CentralAtendimento.tsx
@@ -6,52 +6,54 @@ import { KanbanSquare, Star, Zap } from "lucide-react";
 
 export function CentralAtendimento() {
   return (
-    <div className="min-h-screen">
-      <section className="container mx-auto px-4 pt-32 md:pt-36 pb-16" aria-labelledby="central-hero">
-        <Badge variant="secondary" className="mb-3">Central de Atendimento</Badge>
-        <h1 id="central-hero" className="text-3xl md:text-5xl font-bold tracking-tight">Central de Conversas com funil</h1>
-        <p className="mt-4 text-muted-foreground text-lg">
-          Gerencie atendimentos em tempo real e automatize fluxos.
-        </p>
+      <div className="min-h-screen">
+        <section className="section--first pb-16" aria-labelledby="central-hero">
+          <div className="container mx-auto px-4">
+            <Badge variant="secondary" className="mb-3">Central de Atendimento</Badge>
+            <h1 id="central-hero" className="text-3xl md:text-5xl font-bold tracking-tight">Central de Conversas com funil</h1>
+            <p className="mt-4 text-muted-foreground text-lg">
+              Gerencie atendimentos em tempo real e automatize fluxos.
+            </p>
 
-        <Tabs defaultValue="abertos" className="mt-8">
-          <TabsList className="grid w-full grid-cols-4 md:w-auto">
-            <TabsTrigger value="abertos">Abertos</TabsTrigger>
-            <TabsTrigger value="pendentes">Pendentes</TabsTrigger>
-            <TabsTrigger value="resolvidos">Resolvidos</TabsTrigger>
-            <TabsTrigger value="chatbot">Chatbot</TabsTrigger>
-          </TabsList>
-          <TabsContent value="abertos" className="mt-6 grid md:grid-cols-2 gap-4">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2"><KanbanSquare className="h-5 w-5" /> Gestão de Oportunidades</CardTitle>
-                <CardDescription>Visualização em kanban das conversas</CardDescription>
-              </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                Acompanhe estágios, atribua responsáveis e registre atividades em cada oportunidade.
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2"><Star className="h-5 w-5" /> Avaliação de Atendimento</CardTitle>
-                <CardDescription>Feedback direto dos clientes</CardDescription>
-              </CardHeader>
-              <CardContent className="text-sm text-muted-foreground">
-                Colete notas e comentários ao finalizar cada conversa.
-              </CardContent>
-            </Card>
-          </TabsContent>
-          <TabsContent value="pendentes" className="mt-6 text-sm text-muted-foreground">
-            <p>Conversas aguardando retorno ficam em evidência para garantir SLAs e prazos.</p>
-          </TabsContent>
-          <TabsContent value="resolvidos" className="mt-6 text-sm text-muted-foreground">
-            <p>Histórico completo e exportação das conversas finalizadas.</p>
-          </TabsContent>
-          <TabsContent value="chatbot" className="mt-6 text-sm text-muted-foreground">
-            <p>Automatize triagem e respostas com fluxos e IA integrados.</p>
-          </TabsContent>
-        </Tabs>
-      </section>
+            <Tabs defaultValue="abertos" className="mt-8">
+              <TabsList className="grid w-full grid-cols-4 md:w-auto">
+                <TabsTrigger value="abertos">Abertos</TabsTrigger>
+                <TabsTrigger value="pendentes">Pendentes</TabsTrigger>
+                <TabsTrigger value="resolvidos">Resolvidos</TabsTrigger>
+                <TabsTrigger value="chatbot">Chatbot</TabsTrigger>
+              </TabsList>
+              <TabsContent value="abertos" className="mt-6 grid md:grid-cols-2 gap-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2"><KanbanSquare className="h-5 w-5" /> Gestão de Oportunidades</CardTitle>
+                    <CardDescription>Visualização em kanban das conversas</CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    Acompanhe estágios, atribua responsáveis e registre atividades em cada oportunidade.
+                  </CardContent>
+                </Card>
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2"><Star className="h-5 w-5" /> Avaliação de Atendimento</CardTitle>
+                    <CardDescription>Feedback direto dos clientes</CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    Colete notas e comentários ao finalizar cada conversa.
+                  </CardContent>
+                </Card>
+              </TabsContent>
+              <TabsContent value="pendentes" className="mt-6 text-sm text-muted-foreground">
+                <p>Conversas aguardando retorno ficam em evidência para garantir SLAs e prazos.</p>
+              </TabsContent>
+              <TabsContent value="resolvidos" className="mt-6 text-sm text-muted-foreground">
+                <p>Histórico completo e exportação das conversas finalizadas.</p>
+              </TabsContent>
+              <TabsContent value="chatbot" className="mt-6 text-sm text-muted-foreground">
+                <p>Automatize triagem e respostas com fluxos e IA integrados.</p>
+              </TabsContent>
+            </Tabs>
+          </div>
+        </section>
 
       <section className="container mx-auto px-4 py-10" aria-labelledby="central-planos">
         <h2 id="central-planos" className="sr-only">Planos e valores</h2>

--- a/frontend/src/pages/ChatWhatsapp.tsx
+++ b/frontend/src/pages/ChatWhatsapp.tsx
@@ -5,10 +5,11 @@ import { MessagesSquare, CalendarClock, QrCode, Cpu, ShieldCheck, Users, Bot, We
 
 export default function ChatWhatsapp() {
   return (
-    <div className="min-h-screen">
-      {/* Hero */}
-      <section className="container mx-auto px-4 pt-32 md:pt-36 pb-16" aria-labelledby="chatwhats-hero">
-        <div className="grid md:grid-cols-2 gap-10 items-center">
+      <div className="min-h-screen">
+        {/* Hero */}
+        <section className="section--first pb-16" aria-labelledby="chatwhats-hero">
+          <div className="container mx-auto px-4">
+            <div className="grid md:grid-cols-2 gap-10 items-center">
           <div>
             <Badge variant="secondary" className="mb-3">WhatsApp Omnichannel</Badge>
             <h1 id="chatwhats-hero" className="text-3xl md:text-5xl font-bold tracking-tight">Chat WhatsApp com automações e IA</h1>
@@ -82,6 +83,7 @@ export default function ChatWhatsapp() {
             </Card>
           </div>
         </div>
+      </div>
       </section>
 
       {/* O que você consegue fazer */}


### PR DESCRIPTION
## Summary
- vertically center first sections and set 60vh minimum height
- use shared first-section styling on ChatWhatsapp and CentralAtendimento pages

## Testing
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c055bf70548330bcc4dcb18c7343fe