### PR TITLE
feat: enlarge email hero section

### DIFF
--- a/frontend/src/pages/EmailCorporativo.tsx
+++ b/frontend/src/pages/EmailCorporativo.tsx
@@ -26,7 +26,7 @@ const EmailCorporativo = () => {
       {/* Hero Section */}
       <section
         id="hero"
-        className="section--first pb-16 px-4 bg-gradient-to-br from-primary/5 via-background to-primary/5"
+        className="section--first min-h-[80vh] px-4 bg-gradient-to-br from-primary/5 via-background to-primary/5"
       >
         <div className="container mx-auto text-center">
           <Badge className="mb-4 px-4 py-2">Email Profissional</Badge>


### PR DESCRIPTION
## Summary
- enlarge email page hero section to 80vh and center its content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c057d839e88330a29391d1178b6554