### PR TITLE
Fix Libras team image paths

### DIFF
--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -153,22 +153,21 @@ export default function LibrasPage() {
         </div>
 
         {(() => {
-          const BASE = import.meta.env.BASE_URL || "/";
           const team = [
             {
               name: "Camila Azevedo",
               formacao: "Bacharelado em Letras/Libras (UFSC) · Certificação Prolibras (MEC)",
-              src: `${BASE}team/camila.jpg`,
+              src: "/team/camila.jpg",
             },
             {
               name: "Rafael Nogueira",
               formacao: "Licenciatura em Letras/Libras (UFRJ) · Esp. em Tradução e Interpretação de Libras (PUC-SP)",
-              src: `${BASE}team/rafael.jpg`,
+              src: "/team/rafael.jpg",
             },
             {
               name: "Winove",
               formacao: "Em breve",
-              src: `${BASE}team/winove.jpg`,
+              src: "/team/winove.jpg",
             },
           ];
 
@@ -181,7 +180,7 @@ export default function LibrasPage() {
                 >
                   <img
                     src={m.src}
-                    onError={(e) => { (e.currentTarget as HTMLImageElement).src = `${BASE}placeholder.svg`; }}
+                    onError={(e) => { (e.currentTarget as HTMLImageElement).src = "/placeholder.svg"; }}
                     alt={`Foto de ${m.name}`}
                     loading="lazy"
                     decoding="async"


### PR DESCRIPTION
## Summary
- Fix team member image URLs on Libras page to use absolute paths

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c06d3efe048330ba12a46d1e619945