### PR TITLE
fix: respect base URL for team images

### DIFF
--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -157,17 +157,17 @@ export default function LibrasPage() {
             {
               name: "Camila Azevedo",
               formacao: "Bacharelado em Letras/Libras (UFSC) · Certificação Prolibras (MEC)",
-              src: "/team/camila.jpg",
+              src: `${BASE}team/camila.jpg`,
             },
             {
               name: "Rafael Nogueira",
               formacao: "Licenciatura em Letras/Libras (UFRJ) · Esp. em Tradução e Interpretação de Libras (PUC-SP)",
-              src: "/team/rafael.jpg",
+              src: `${BASE}team/rafael.jpg`,
             },
             {
               name: "Winove",
               formacao: "Em breve",
-              src: "/team/winove.jpg",
+              src: `${BASE}team/winove.jpg`,
             },
           ];
 


### PR DESCRIPTION
## Summary
- use Vite BASE_URL for Libras team member images

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06f85b3d8833090c7587dfa4a319e