### PR TITLE
feat: allow custom base path

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: process.env.BASE_PATH || "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- read base path from BASE_PATH environment variable

## Testing
- `npm run lint`
- `BASE_PATH=/demo/winove npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07e9e7f0c83309118d61e5c03857c