### PR TITLE
Fix static asset serving and Vite base path

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -44,6 +44,17 @@ app.use((_req, res, next) => {
   next();
 });
 
+// Serve frontend build from ../frontend/dist
+const distPath = path.join(__dirname, '../frontend/dist');
+app.use(
+  '/assets',
+  express.static(path.join(distPath, 'assets'), {
+    immutable: true,
+    maxAge: '1y',
+  })
+);
+app.use(express.static(distPath));
+
 // API routes
 app.use('/api/blog-posts', blogPostsRoute);
 app.use('/api/cases', casesRoute);
@@ -59,12 +70,9 @@ app.get('/api/health', (_req, res) => {
 // API 404
 app.use('/api', (_req, res) => res.status(404).json({ error: 'not_found' }));
 
-// Serve frontend build from ../frontend/dist
-const distPath = path.join(__dirname, '../frontend/dist');
-app.use(express.static(distPath));
-
 // SPA fallback for React Router
-app.get('*', (_req, res) => {
+app.get('*', (req, res) => {
+  if (req.path.includes('.')) return res.status(404).end();
   res.sendFile(path.join(distPath, 'index.html'));
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: process.env.BASE_PATH || "/",
+  base: process.env.BASE_PATH || "./",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- serve built assets before API routes and return 404 for unknown files
- set Vite base to './' to support subdirectory deployments

## Testing
- `npm run lint` (frontend)
- `npm run build` (frontend)
- `npm test` (backend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c08b57eac08330abc67b71c077e149