### PR TITLE
feat: improve SEO with structured data

### DIFF
--- a/blog/index.php
+++ b/blog/index.php
@@ -28,6 +28,31 @@
 
           container.appendChild(div);
         });
+
+        const ldJson = {
+          "@context": "https://schema.org",
+          "@type": "Blog",
+          "blogPost": posts.map(post => ({
+            "@type": "BlogPosting",
+            "headline": post.titulo,
+            "image": post.imagem,
+            "author": {
+              "@type": "Person",
+              "name": post.autor || "Winove"
+            },
+            "datePublished": post.criado_em,
+            "description": post.resumo,
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": `https://www.winove.com.br/blog/${post.slug}`
+            }
+          }))
+        };
+
+        const script = document.createElement('script');
+        script.type = 'application/ld+json';
+        script.textContent = JSON.stringify(ldJson);
+        document.head.appendChild(script);
       })
       .catch(err => {
         console.error("Erro ao carregar posts:", err);

--- a/blog/slug.php
+++ b/blog/slug.php
@@ -27,10 +27,31 @@ if (!$post) {
 ?>
 
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
   <title><?= htmlspecialchars($post['titulo']) ?></title>
+  <meta name="description" content="<?= htmlspecialchars($post['resumo'] ?? '') ?>" />
+  <link rel="canonical" href="https://www.winove.com.br/blog/<?= urlencode($slug) ?>" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": <?= json_encode($post['titulo']) ?>,
+    "image": <?= json_encode($post['imagem']) ?>,
+    "author": {
+      "@type": "Person",
+      "name": <?= json_encode($post['autor']) ?>
+    },
+    "datePublished": <?= json_encode(date(DATE_ATOM, strtotime($post['criado_em']))) ?>,
+    "dateModified": <?= json_encode(date(DATE_ATOM, strtotime($post['criado_em']))) ?>,
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://www.winove.com.br/blog/<?= urlencode($slug) ?>"
+    },
+    "description": <?= json_encode($post['resumo'] ?? '') ?>
+  }
+  </script>
   <style>
     body { font-family: Arial; max-width: 800px; margin: auto; padding: 20px; }
     img { max-width: 100%; margin-bottom: 20px; }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -37,6 +37,20 @@
         "@type": "ContactPoint",
         "telephone": "+55-19-98240-3845",
         "contactType": "Customer Support"
+      }
+    }
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "url": "https://www.winove.com.br/",
+      "name": "Winove",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "https://www.winove.com.br/busca?q={search_term_string}",
+        "query-input": "required name=search_term_string"
       }
     }
     </script>

--- a/frontend/src/lib/seo.ts
+++ b/frontend/src/lib/seo.ts
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+
+interface SEOOptions {
+  title: string;
+  description: string;
+  canonical?: string;
+  noindex?: boolean;
+  jsonLd?: Record<string, unknown>;
+}
+
+export function useSEO({ title, description, canonical, noindex, jsonLd }: SEOOptions) {
+  useEffect(() => {
+    if (title) document.title = title;
+
+    if (description) {
+      let meta = document.querySelector<HTMLMetaElement>("meta[name='description']");
+      if (!meta) {
+        meta = document.createElement("meta");
+        meta.name = "description";
+        document.head.appendChild(meta);
+      }
+      meta.content = description;
+    }
+
+    let link = document.querySelector<HTMLLinkElement>("link[rel='canonical']");
+    if (canonical) {
+      if (!link) {
+        link = document.createElement("link");
+        link.rel = "canonical";
+        document.head.appendChild(link);
+      }
+      link.href = canonical;
+    } else if (link) {
+      document.head.removeChild(link);
+    }
+
+    let robots = document.querySelector<HTMLMetaElement>("meta[name='robots'][data-seo]");
+    if (noindex) {
+      if (!robots) {
+        robots = document.createElement("meta");
+        robots.name = "robots";
+        robots.setAttribute("data-seo", "true");
+        document.head.appendChild(robots);
+      }
+      robots.content = "noindex";
+    } else if (robots) {
+      document.head.removeChild(robots);
+    }
+
+    let script = document.querySelector<HTMLScriptElement>("script[data-seo-jsonld]");
+    if (jsonLd) {
+      if (!script) {
+        script = document.createElement("script");
+        script.type = "application/ld+json";
+        script.setAttribute("data-seo-jsonld", "true");
+        document.head.appendChild(script);
+      }
+      script.text = JSON.stringify(jsonLd);
+    } else if (script) {
+      document.head.removeChild(script);
+    }
+  }, [title, description, canonical, noindex, jsonLd]);
+}
+

--- a/frontend/src/pages/BlogList.tsx
+++ b/frontend/src/pages/BlogList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Calendar, User, ArrowRight } from "lucide-react";
 import { Footer } from "@/components/Footer";
+import { useSEO } from "@/lib/seo";
 
 interface BlogPost {
   id: number;
@@ -46,6 +47,27 @@ export const BlogList = () => {
     };
     load();
   }, []);
+
+  useSEO({
+    title: "Blog & Insights | Winove",
+    description:
+      "Conteúdos exclusivos, tendências e estratégias para manter seu negócio sempre à frente no mundo digital",
+    canonical: "https://www.winove.com.br/blog",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "Blog",
+      name: "Winove Blog",
+      url: "https://www.winove.com.br/blog",
+      blogPost: allPosts?.map((p) => ({
+        "@type": "BlogPosting",
+        headline: p.title,
+        image: p.coverImage,
+        datePublished: p.date,
+        author: { "@type": "Person", name: p.author },
+        url: `https://www.winove.com.br/blog/${p.slug}`,
+      })),
+    },
+  });
 
   if (!allPosts) {
     return <p>Carregando...</p>;

--- a/frontend/src/pages/BlogPost.tsx
+++ b/frontend/src/pages/BlogPost.tsx
@@ -2,6 +2,7 @@ import { useParams, Link } from "react-router-dom";
 import { Calendar, User, ArrowLeft, Clock, Share2 } from "lucide-react";
 import { Footer } from "@/components/Footer";
 import { useEffect, useState } from "react";
+import { useSEO } from "@/lib/seo";
 
 interface BlogPost {
   id: number;
@@ -58,6 +59,23 @@ export const BlogPost = () => {
     load();
     window.scrollTo(0, 0);
   }, [slug]);
+
+  useSEO({
+    title: post ? `${post.title} | Blog Winove` : "Blog Winove",
+    description: post?.excerpt || "",
+    canonical: post ? `https://www.winove.com.br/blog/${post.slug}` : undefined,
+    jsonLd: post
+      ? {
+          "@context": "https://schema.org",
+          "@type": "BlogPosting",
+          headline: post.title,
+          image: post.coverImage,
+          datePublished: post.date,
+          author: { "@type": "Person", name: post.author },
+          url: `https://www.winove.com.br/blog/${post.slug}`,
+        }
+      : undefined,
+  });
 
   if (!post) {
     return (

--- a/frontend/src/pages/CaseDetail.tsx
+++ b/frontend/src/pages/CaseDetail.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Calendar, TrendingUp, Target, Lightbulb, Trophy, ArrowRight 
 import { Footer } from "@/components/Footer";
 import { useEffect, useState } from "react";
 import { CaseItem, Metric, safeArray } from "@/lib/caseUtils";
+import { useSEO } from "@/lib/seo";
 
 export const CaseDetail = () => {
   const { slug } = useParams<{ slug: string }>();
@@ -47,6 +48,23 @@ export const CaseDetail = () => {
     load();
     window.scrollTo(0, 0);
   }, [slug]);
+
+  useSEO({
+    title: caseItem ? `${caseItem.title} | Case de Sucesso | Winove` : "Case | Winove",
+    description: caseItem?.excerpt || "",
+    canonical: caseItem ? `https://www.winove.com.br/cases/${caseItem.slug}` : undefined,
+    jsonLd: caseItem
+      ? {
+          "@context": "https://schema.org",
+          "@type": "CaseStudy",
+          name: caseItem.title,
+          description: caseItem.excerpt,
+          datePublished: caseItem.date,
+          author: { "@type": "Organization", name: "Winove" },
+          url: `https://www.winove.com.br/cases/${caseItem.slug}`,
+        }
+      : undefined,
+  });
 
   if (!caseItem) {
     return (

--- a/frontend/src/pages/CasesList.tsx
+++ b/frontend/src/pages/CasesList.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, ExternalLink, TrendingUp } from "lucide-react";
 import { Footer } from "@/components/Footer";
 import { useEffect, useState } from "react";
 import { CaseItem, Metric, safeArray } from "@/lib/caseUtils";
+import { useSEO } from "@/lib/seo";
 
 export const CasesList = () => {
   const [items, setItems] = useState<CaseItem[]>([]);
@@ -30,6 +31,24 @@ export const CasesList = () => {
     };
     load();
   }, []);
+
+  useSEO({
+    title: "Cases de Sucesso | Winove",
+    description:
+      "Projetos que transformaram negócios e geraram resultados excepcionais para nossos clientes",
+    canonical: "https://www.winove.com.br/cases",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      name: "Cases de Sucesso",
+      url: "https://www.winove.com.br/cases",
+      hasPart: items.map((c) => ({
+        "@type": "CaseStudy",
+        name: c.title,
+        url: `https://www.winove.com.br/cases/${c.slug}`,
+      })),
+    },
+  });
 
   return (
     <div className="min-h-screen bg-background">

--- a/frontend/src/pages/CentralAtendimento.tsx
+++ b/frontend/src/pages/CentralAtendimento.tsx
@@ -3,8 +3,22 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { KanbanSquare, Star, Zap } from "lucide-react";
+import { useSEO } from "@/lib/seo";
 
 export function CentralAtendimento() {
+  useSEO({
+    title: "Central de Conversas com Funil | Winove",
+    description: "Gerencie atendimentos em tempo real e automatize fluxos.",
+    canonical: "https://www.winove.com.br/central-atendimento",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "Central de Conversas com Funil",
+      provider: { "@type": "Organization", name: "Winove" },
+      serviceType: "Central de atendimento",
+    },
+  });
+
   return (
       <div className="min-h-screen">
         <section className="section--first pb-16" aria-labelledby="central-hero">

--- a/frontend/src/pages/ChatWhatsapp.tsx
+++ b/frontend/src/pages/ChatWhatsapp.tsx
@@ -2,8 +2,23 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MessagesSquare, CalendarClock, QrCode, Cpu, ShieldCheck, Users, Bot, Webhook, Settings, Zap, PhoneCall, Clock8, BarChart3, Server, Link as LinkIcon } from "lucide-react";
+import { useSEO } from "@/lib/seo";
 
 export default function ChatWhatsapp() {
+  useSEO({
+    title: "Chat WhatsApp com automações e IA | Winove",
+    description:
+      "Conecte um número geral do seu negócio, distribua conversas entre múltiplos atendentes e acelere respostas com fluxos, IA e integrações.",
+    canonical: "https://www.winove.com.br/chat-whatsapp",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "Chat WhatsApp com automações e IA",
+      provider: { "@type": "Organization", name: "Winove" },
+      serviceType: "Atendimento via WhatsApp",
+    },
+  });
+
   return (
       <div className="min-h-screen">
         {/* Hero */}

--- a/frontend/src/pages/EmailCorporativo.tsx
+++ b/frontend/src/pages/EmailCorporativo.tsx
@@ -8,6 +8,7 @@ import {
   Share2, Settings, Zap, Cloud, Smartphone,
   PhoneCall, MessageCircle
 } from "lucide-react";
+import { useSEO } from "@/lib/seo";
 
 const EmailCorporativo = () => {
   const features = [
@@ -20,6 +21,21 @@ const EmailCorporativo = () => {
     { icon: FileText, title: "Notas", description: "Espaço reservado para suas ideias e informações relevantes" },
     { icon: MessageSquare, title: "Reuniões", description: "Não precisa instalar software, sem limite de tempo, faça suas reuniões com nossa tecnologia." },
   ];
+
+  useSEO({
+    title: "E-mail Corporativo Profissional | Winove",
+    description:
+      "Contas a partir de 5 GB com Antivirus, Antispam com 3 níveis de filtragem, acesso por Webmail, POP e IMAP.",
+    canonical: "https://www.winove.com.br/email-corporativo",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      name: "E-mail Corporativo",
+      provider: { "@type": "Organization", name: "Winove" },
+      areaServed: "Brasil",
+      serviceType: "E-mail corporativo profissional",
+    },
+  });
 
   return (
     <div className="min-h-screen bg-background text-foreground">

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -8,11 +8,25 @@ import { CTA } from "@/components/CTA";
 import { Footer } from "@/components/Footer";
 import { useQuery } from '@tanstack/react-query';
 import { fetchTemplate } from '@/lib/api';
+import { useSEO } from "@/lib/seo";
 
 const Index = () => {
   const { data } = useQuery({
     queryKey: ['template', 'home-hero'],
     queryFn: () => fetchTemplate('home-hero'),
+  });
+
+  useSEO({
+    title: "Winove - Soluções Criativas e Resultados Reais",
+    description:
+      "A Winove entrega soluções digitais que transformam negócios. Descubra nossos cases de sucesso, serviços e portfólio.",
+    canonical: "https://www.winove.com.br/",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: "Início - Winove",
+      url: "https://www.winove.com.br/",
+    },
   });
 
   return (

--- a/frontend/src/pages/Libras.tsx
+++ b/frontend/src/pages/Libras.tsx
@@ -1,54 +1,45 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { LibrasLeadForm } from "@/components/forms/LibrasLeadForm";
 import heroBg from "@/assets/hero-background.jpg";
+import { useSEO } from "@/lib/seo";
 
 export default function LibrasPage() {
   const [sent, setSent] = useState(false);
 
-  useEffect(() => {
-    document.title = "Interpretação de Libras em SP e Janela de Libras para Vídeos | Winove";
-    const metaDesc =
-      "Cobertura presencial em São Paulo e janela de Libras para vídeos. Equipes certificadas, NBR 15290 e revezamento para eventos >1h. Proposta em até 24h.";
-    let meta = document.querySelector("meta[name='description']");
-    if (!meta) {
-      meta = document.createElement("meta");
-      meta.setAttribute("name", "description");
-      document.head.appendChild(meta);
-    }
-    meta.setAttribute("content", metaDesc);
-
-    const robots = document.createElement("meta");
-    robots.setAttribute("name", "robots");
-    robots.setAttribute("content", "noindex");
-    robots.setAttribute("data-page", "libras");
-    document.head.appendChild(robots);
-
-    const script = document.createElement("script");
-    script.type = "application/ld+json";
-    script.text = JSON.stringify({
+  useSEO({
+    title: "Interpretação de Libras em SP e Janela de Libras para Vídeos | Winove",
+    description:
+      "Cobertura presencial em São Paulo e janela de Libras para vídeos. Equipes certificadas, NBR 15290 e revezamento para eventos >1h. Proposta em até 24h.",
+    canonical: "https://www.winove.com.br/servicos/libras",
+    noindex: true,
+    jsonLd: {
       "@context": "https://schema.org",
       "@type": "Service",
-      "name": "Interpretação de Libras (SP) e Janela de Libras para Vídeos",
-      "provider": { "@type": "Organization", "name": "Winove" },
-      "areaServed": { "@type": "AdministrativeArea", "name": "São Paulo" },
-      "serviceType": "Libras Presencial; Janela de Libras",
-      "offers": { "@type": "Offer", "availability": "https://schema.org/InStock" },
-      "audience": { "@type": "Audience", "audienceType": ["Empresas", "Palestrantes", "Produtoras"] },
-      "hasOfferCatalog": {
+      name: "Interpretação de Libras (SP) e Janela de Libras para Vídeos",
+      provider: { "@type": "Organization", name: "Winove" },
+      areaServed: { "@type": "AdministrativeArea", name: "São Paulo" },
+      serviceType: "Libras Presencial; Janela de Libras",
+      offers: { "@type": "Offer", availability: "https://schema.org/InStock" },
+      audience: {
+        "@type": "Audience",
+        audienceType: ["Empresas", "Palestrantes", "Produtoras"],
+      },
+      hasOfferCatalog: {
         "@type": "OfferCatalog",
-        "name": "Formatos",
-        "itemListElement": [
-          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Presencial (SP)" } },
-          { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Conteúdos gravados (Janela de Libras)" } }
-        ]
-      }
-    });
-    document.head.appendChild(script);
-    return () => {
-      document.head.removeChild(script);
-      document.head.removeChild(robots);
-    };
-  }, []);
+        name: "Formatos",
+        itemListElement: [
+          { "@type": "Offer", itemOffered: { "@type": "Service", name: "Presencial (SP)" } },
+          {
+            "@type": "Offer",
+            itemOffered: {
+              "@type": "Service",
+              name: "Conteúdos gravados (Janela de Libras)",
+            },
+          },
+        ],
+      },
+    },
+  });
 
   // Assets públicos devem usar caminho absoluto para não quebrar em rotas aninhadas
   const videoSrc = `/assets/hero-libras.mp4?v=2`;

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { useQuery } from '@tanstack/react-query';
 import { fetchTemplates, Template } from '@/lib/api';
 import { Search, Eye, Star, Filter } from "lucide-react";
+import { useSEO } from "@/lib/seo";
 
 const Templates = () => {
   const [selectedCategory, setSelectedCategory] = useState("Todos");
@@ -41,6 +42,19 @@ const Templates = () => {
         tag.toLowerCase().includes(searchTerm.toLowerCase())
       );
     return matchesCategory && matchesSearch;
+  });
+
+  useSEO({
+    title: "Templates Wix Studio | Winove",
+    description:
+      "Acelere seu projeto com nossos templates profissionais para Wix Studio. Designs modernos, responsivos e otimizados para conversão.",
+    canonical: "https://www.winove.com.br/templates",
+    jsonLd: {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      name: "Templates Wix Studio",
+      url: "https://www.winove.com.br/templates",
+    },
   });
 
   return (

--- a/httpdocs/blog/index.php
+++ b/httpdocs/blog/index.php
@@ -28,6 +28,31 @@
 
           container.appendChild(div);
         });
+
+        const ldJson = {
+          "@context": "https://schema.org",
+          "@type": "Blog",
+          "blogPost": posts.map(post => ({
+            "@type": "BlogPosting",
+            "headline": post.titulo,
+            "image": post.imagem,
+            "author": {
+              "@type": "Person",
+              "name": post.autor || "Winove"
+            },
+            "datePublished": post.criado_em,
+            "description": post.resumo,
+            "mainEntityOfPage": {
+              "@type": "WebPage",
+              "@id": `https://www.winove.com.br/blog/${post.slug}`
+            }
+          }))
+        };
+
+        const script = document.createElement('script');
+        script.type = 'application/ld+json';
+        script.textContent = JSON.stringify(ldJson);
+        document.head.appendChild(script);
       })
       .catch(err => {
         console.error("Erro ao carregar posts:", err);

--- a/httpdocs/blog/slug.php
+++ b/httpdocs/blog/slug.php
@@ -27,10 +27,31 @@ if (!$post) {
 ?>
 
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-BR">
 <head>
   <meta charset="UTF-8" />
   <title><?= htmlspecialchars($post['titulo']) ?></title>
+  <meta name="description" content="<?= htmlspecialchars($post['resumo'] ?? '') ?>" />
+  <link rel="canonical" href="https://www.winove.com.br/blog/<?= urlencode($slug) ?>" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": <?= json_encode($post['titulo']) ?>,
+    "image": <?= json_encode($post['imagem']) ?>,
+    "author": {
+      "@type": "Person",
+      "name": <?= json_encode($post['autor']) ?>
+    },
+    "datePublished": <?= json_encode(date(DATE_ATOM, strtotime($post['criado_em']))) ?>,
+    "dateModified": <?= json_encode(date(DATE_ATOM, strtotime($post['criado_em']))) ?>,
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://www.winove.com.br/blog/<?= urlencode($slug) ?>"
+    },
+    "description": <?= json_encode($post['resumo'] ?? '') ?>
+  }
+  </script>
   <style>
     body { font-family: Arial; max-width: 800px; margin: auto; padding: 20px; }
     img { max-width: 100%; margin-bottom: 20px; }


### PR DESCRIPTION
## Summary
- introduce reusable `useSEO` hook to manage page metadata and structured data
- apply on-page SEO across home, service, and content pages (Templates, Email Corporativo, Chat WhatsApp, Libras, Central de Atendimento, Blog, Cases)

## Testing
- `npm run lint`
- `php -l httpdocs/blog/slug.php`
- `php -l httpdocs/blog/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68c095bd93088330aa7c651654b615b6