### PR TITLE
Fix blog posts API for Winove website

### DIFF
--- a/blog/slug.php
+++ b/blog/slug.php
@@ -38,7 +38,7 @@ if (!$post) {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": <?= json_encode($post['titulo']) ?>,
-    "image": <?= json_encode($post['imagem']) ?>,
+    "image": <?= json_encode($post['imagem_destacada']) ?>,
     "author": {
       "@type": "Person",
       "name": <?= json_encode($post['autor']) ?>
@@ -64,7 +64,7 @@ if (!$post) {
   <h1><?= htmlspecialchars($post['titulo']) ?></h1>
   <div class="meta">Publicado em <?= date("d/m/Y", strtotime($post['criado_em'])) ?> por <?= htmlspecialchars($post['autor']) ?></div>
 
-  <img src="<?= htmlspecialchars($post['imagem']) ?>" alt="Imagem destacada" />
+  <img src="<?= htmlspecialchars($post['imagem_destacada']) ?>" alt="Imagem destacada" />
 
   <div>
     <?= $post['conteudo'] ?>

--- a/httpdocs/api/blog-posts.php
+++ b/httpdocs/api/blog-posts.php
@@ -11,9 +11,9 @@ if ($conn->connect_error) {
 
 
 
-$result = $conn->query("SELECT id, titulo AS title, slug, resumo AS excerpt, conteudo AS content, imagem AS coverImage, criado_em AS date, autor, categoria AS category FROM blog_posts ORDER BY criado_em DESC");
-=======
-$result = $conn->query("SELECT id, titulo, slug, resumo, conteudo, imagem AS imagem_destacada, criado_em AS data_publicacao, autor, categoria FROM blog_posts ORDER BY criado_em DESC");
+$result = $conn->query(
+  "SELECT id, titulo, slug, resumo, conteudo, imagem_destacada AS imagem, criado_em, autor, categoria FROM blog_posts ORDER BY criado_em DESC"
+);
 
 
 


### PR DESCRIPTION
## Summary
- fix blog posts API query and remove leftover merge markers
- use correct image field on blog post pages

## Testing
- `php -l httpdocs/api/blog-posts.php`
- `php -l blog/slug.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0b3f666dc833090fcae66a8f9216a