### PR TITLE
Fix blog posts API for Winove website

### DIFF
--- a/backend/routes/blogPosts.js
+++ b/backend/routes/blogPosts.js
@@ -37,37 +37,6 @@ router.get('/', async (req, res) => {
   }
 });
 
-// 1 post por slug
-// Slug detalhado (evita conflito com rotas como /search, /categories)
-router.get('/:slug([A-Za-z0-9-]+)', async (req, res) => {
-  try {
-    const [rows] = await pool.query(
-      `
-      SELECT
-        id,
-        titulo AS title,
-        slug,
-        resumo AS excerpt,
-        conteudo AS content,
-        imagem_destacada AS coverImage,
-        data_publicacao AS date,
-        autor AS author,
-        categoria AS category
-      FROM blog_posts
-      WHERE slug = ?
-      LIMIT 1
-    `,
-      [req.params.slug]
-    );
-
-    if (!rows?.length) return res.status(404).json({ error: 'Post não encontrado' });
-    res.json(rows[0]);
-  } catch (err) {
-    console.error('GET /api/blog-posts/:slug ->', err);
-    res.status(500).json({ error: 'Erro ao carregar post' });
-  }
-});
-
 // Busca com filtros + paginação
 router.get('/search', async (req, res) => {
   try {
@@ -139,6 +108,36 @@ router.get('/categories', async (_req, res) => {
   } catch (err) {
     console.error('GET /api/blog-posts/categories ->', err);
     res.status(500).json({ error: 'Erro ao carregar categorias' });
+  }
+});
+
+// 1 post por slug (colocado por último para evitar conflitos com rotas acima)
+router.get('/:slug([A-Za-z0-9-]+)', async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      `
+      SELECT
+        id,
+        titulo AS title,
+        slug,
+        resumo AS excerpt,
+        conteudo AS content,
+        imagem_destacada AS coverImage,
+        data_publicacao AS date,
+        autor AS author,
+        categoria AS category
+      FROM blog_posts
+      WHERE slug = ?
+      LIMIT 1
+    `,
+      [req.params.slug]
+    );
+
+    if (!rows?.length) return res.status(404).json({ error: 'Post não encontrado' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('GET /api/blog-posts/:slug ->', err);
+    res.status(500).json({ error: 'Erro ao carregar post' });
   }
 });
 

--- a/blog/slug.php
+++ b/blog/slug.php
@@ -38,7 +38,7 @@ if (!$post) {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": <?= json_encode($post['titulo']) ?>,
-    "image": <?= json_encode($post['imagem']) ?>,
+    "image": <?= json_encode($post['imagem_destacada']) ?>,
     "author": {
       "@type": "Person",
       "name": <?= json_encode($post['autor']) ?>
@@ -64,7 +64,7 @@ if (!$post) {
   <h1><?= htmlspecialchars($post['titulo']) ?></h1>
   <div class="meta">Publicado em <?= date("d/m/Y", strtotime($post['criado_em'])) ?> por <?= htmlspecialchars($post['autor']) ?></div>
 
-  <img src="<?= htmlspecialchars($post['imagem']) ?>" alt="Imagem destacada" />
+  <img src="<?= htmlspecialchars($post['imagem_destacada']) ?>" alt="Imagem destacada" />
 
   <div>
     <?= $post['conteudo'] ?>

--- a/httpdocs/api/blog-posts.php
+++ b/httpdocs/api/blog-posts.php
@@ -11,9 +11,9 @@ if ($conn->connect_error) {
 
 
 
-$result = $conn->query("SELECT id, titulo AS title, slug, resumo AS excerpt, conteudo AS content, imagem AS coverImage, criado_em AS date, autor, categoria AS category FROM blog_posts ORDER BY criado_em DESC");
-=======
-$result = $conn->query("SELECT id, titulo, slug, resumo, conteudo, imagem AS imagem_destacada, criado_em AS data_publicacao, autor, categoria FROM blog_posts ORDER BY criado_em DESC");
+$result = $conn->query(
+  "SELECT id, titulo, slug, resumo, conteudo, imagem_destacada AS imagem, criado_em, autor, categoria FROM blog_posts ORDER BY criado_em DESC"
+);
 
 
 


### PR DESCRIPTION
## Summary
- fix blog posts API query and remove leftover merge markers
- use correct image field on blog post pages
- move slug route after search and category endpoints to prevent conflicts

## Testing
- `php -l httpdocs/api/blog-posts.php`
- `php -l blog/slug.php`
- `node --check backend/routes/blogPosts.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c0b3f666dc833090fcae66a8f9216a